### PR TITLE
Updated Pei and TransportLibKcs base instance to not require global m…

### DIFF
--- a/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
@@ -12,7 +12,6 @@
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/IpmiPlatformHookLib.h>
 
-STATIC EFI_PEI_PPI_DESCRIPTOR  gPeiIpmiBmcDataDesc;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Function Implementations
@@ -34,6 +33,7 @@ PeiInitializeIpmiPhysicalLayer (
 {
   EFI_STATUS              Status;
   IPMI_BMC_INSTANCE_DATA  *mIpmiInstance;
+  EFI_PEI_PPI_DESCRIPTOR  *mPeiIpmiBmcDataDesc;
 
   mIpmiInstance = NULL;
 
@@ -46,12 +46,16 @@ PeiInitializeIpmiPhysicalLayer (
       return Status;
     }
   }
-
-  mIpmiInstance = AllocateZeroPool (sizeof (IPMI_BMC_INSTANCE_DATA));
+  //
+  // Make one allocation for both the PPI descriptor and the Bmc Instance data
+  //
+  mIpmiInstance = AllocateZeroPool (sizeof (IPMI_BMC_INSTANCE_DATA) + sizeof(EFI_PEI_PPI_DESCRIPTOR) );
   if (mIpmiInstance == NULL) {
     DEBUG ((EFI_D_ERROR, "IPMI Peim:EFI_OUT_OF_RESOURCES of memory allocation\n"));
     return EFI_OUT_OF_RESOURCES;
   }
+
+  mPeiIpmiBmcDataDesc = (EFI_PEI_PPI_DESCRIPTOR*)( (UINT8*)mIpmiInstance + sizeof(IPMI_BMC_INSTANCE_DATA));
 
   //
   // Calibrate TSC Counter.  Stall for 10ms, then multiply the resulting number of
@@ -70,9 +74,12 @@ PeiInitializeIpmiPhysicalLayer (
   mIpmiInstance->IpmiTransport.IpmiSubmitCommand = IpmiSendCommand;
   mIpmiInstance->IpmiTransport.GetBmcStatus      = IpmiGetBmcStatus;
 
-  gPeiIpmiBmcDataDesc.Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
-  gPeiIpmiBmcDataDesc.Guid  = &gPeiIpmiTransportPpiGuid;
-  gPeiIpmiBmcDataDesc.Ppi   = &mIpmiInstance->IpmiTransport;
+  //
+  // Initialize the Ppi descriptor
+  //
+  mPeiIpmiBmcDataDesc->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
+  mPeiIpmiBmcDataDesc->Guid  = &gPeiIpmiTransportPpiGuid;
+  mPeiIpmiBmcDataDesc->Ppi   = &mIpmiInstance->IpmiTransport;
 
   //
   // Initialize the transport layer.
@@ -102,7 +109,7 @@ PeiInitializeIpmiPhysicalLayer (
   //
   // Just produce PPI
   //
-  Status = PeiServicesInstallPpi (&gPeiIpmiBmcDataDesc);
+  Status = PeiServicesInstallPpi (mPeiIpmiBmcDataDesc);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
@@ -12,7 +12,6 @@
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/IpmiPlatformHookLib.h>
 
-
 ///////////////////////////////////////////////////////////////////////////////
 // Function Implementations
 //
@@ -46,16 +45,17 @@ PeiInitializeIpmiPhysicalLayer (
       return Status;
     }
   }
+
   //
   // Make one allocation for both the PPI descriptor and the Bmc Instance data
   //
-  mIpmiInstance = AllocateZeroPool (sizeof (IPMI_BMC_INSTANCE_DATA) + sizeof(EFI_PEI_PPI_DESCRIPTOR) );
+  mIpmiInstance = AllocateZeroPool (sizeof (IPMI_BMC_INSTANCE_DATA) + sizeof (EFI_PEI_PPI_DESCRIPTOR));
   if (mIpmiInstance == NULL) {
     DEBUG ((EFI_D_ERROR, "IPMI Peim:EFI_OUT_OF_RESOURCES of memory allocation\n"));
     return EFI_OUT_OF_RESOURCES;
   }
 
-  mPeiIpmiBmcDataDesc = (EFI_PEI_PPI_DESCRIPTOR*)( (UINT8*)mIpmiInstance + sizeof(IPMI_BMC_INSTANCE_DATA));
+  mPeiIpmiBmcDataDesc = (EFI_PEI_PPI_DESCRIPTOR *)((UINT8 *)mIpmiInstance + sizeof (IPMI_BMC_INSTANCE_DATA));
 
   //
   // Calibrate TSC Counter.  Stall for 10ms, then multiply the resulting number of

--- a/IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsIpmiTransportLib.inf
+++ b/IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsIpmiTransportLib.inf
@@ -26,6 +26,7 @@
 
 [LibraryClasses]
   DebugLib
+  IpmiPlatformHookLib
 
 [Pcd]
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress


### PR DESCRIPTION
Updated PeiGenericIpmi and IpmiTransportLibKcs base instance to not use global variables. 

Fixes when PIMs run out of ROM