### PR TITLE
Improvements to the IPMI watchdog implementation

### DIFF
--- a/IpmiFeaturePkg/IpmiCoreLibs.dsc.inc
+++ b/IpmiFeaturePkg/IpmiCoreLibs.dsc.inc
@@ -17,8 +17,8 @@
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.inf
 
-[LibraryClasses.common.DXE_DRIVER,LibraryClasses.common.UEFI_DRIVER]
+[LibraryClasses.common.DXE_DRIVER,LibraryClasses.common.UEFI_DRIVER,LibraryClasses.common.DXE_RUNTIME_DRIVER]
   IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.inf
 
-[LibraryClasses.common.DXE_SMM_DRIVER]
+[LibraryClasses.common.DXE_SMM_DRIVER,LibraryClasses.common.SMM_CORE]
   IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dec
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dec
@@ -55,12 +55,12 @@
   gIpmiFeaturePkgTokenSpaceGuid.PcdBmcTimeoutSeconds|30|UINT8|0xF0000005
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiBmcReadyDelayTimer|120|UINT8|0xF0000006
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiSelOemManufacturerId|{0, 0, 0}|VOID*|0xF0000007
-  gIpmiFeaturePkgTokenSpaceGuid.PcdFrb2EnabledFlag|TRUE|BOOLEAN|0xF0000008
-  gIpmiFeaturePkgTokenSpaceGuid.PcdFrb2TimeoutSeconds|600|UINT16|0xF0000009
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress|0xCA2|UINT16|0xF000000A
-  gIpmiFeaturePkgTokenSpaceGuid.PcdFrb2TimeoutAction|0|UINT8|0xF000000B
 
 [PcdsDynamic, PcdsDynamicEx]
   gIpmiFeaturePkgTokenSpaceGuid.PcdOsWatchdogEnabled|FALSE|BOOLEAN|0xD0000001
   gIpmiFeaturePkgTokenSpaceGuid.PcdOsWatchdogTimeoutSeconds|600|UINT16|0xD0000002
   gIpmiFeaturePkgTokenSpaceGuid.PcdOsWatchdogAction|0|UINT8|0xD0000003
+  gIpmiFeaturePkgTokenSpaceGuid.PcdFrb2EnabledFlag|TRUE|BOOLEAN|0xD0000004
+  gIpmiFeaturePkgTokenSpaceGuid.PcdFrb2TimeoutSeconds|600|UINT16|0xD0000005
+  gIpmiFeaturePkgTokenSpaceGuid.PcdFrb2TimeoutAction|0|UINT8|0xD0000006

--- a/IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.c
+++ b/IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.c
@@ -57,18 +57,3 @@ PlatformIpmiInitialize (
 {
   return EFI_SUCCESS;
 }
-
-/**
-  Performs any platform specific initialization needed for the BMC or IPMI
-  stack.
-
-  @retval   EFI_SUCCESS   The platform initialization was successfully completed.
-**/
-EFI_STATUS
-EFIAPI
-PlatformIpmiGetFrb2Settings (
-  VOID
-  )
-{
-  return EFI_SUCCESS;
-}

--- a/IpmiFeaturePkg/Library/IpmiWatchdogLib/IpmiWatchdogLib.inf
+++ b/IpmiFeaturePkg/Library/IpmiWatchdogLib/IpmiWatchdogLib.inf
@@ -27,6 +27,3 @@
   DebugLib
   TimerLib
   IpmiCommandLib
-
-[Pcd]
-  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiSelOemManufacturerId


### PR DESCRIPTION
- Move FRB2 PCDs to dynamic
- Cleanup unused code and PCDs