### PR TITLE
.azurepipelines: Use new Mu DevOps YAML Design

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -14,29 +14,19 @@ resources:
       name: microsoft/mu_devops
       ref: main
 
-trigger:
-- main
-
-pr:
-- main
-
-schedules:
-- cron: "30 9 * * 0,3"  # Sun/Wed at 2:30AM Pacific
-  displayName: Sun/Wed Build
-  branches:
-    include:
-    - main
-  always: true          # Always build, even if no changes
+variables:
+- group: architectures-arm64-x86-64
+- group: tool-chain-ubuntu-gcc
 
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    arch_list: IA32,X64,AARCH64
+    arch_list: $(arch_list)
     do_ci_build: true
     do_ci_setup: false
     packages: IpmiFeaturePkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
-    tool_chain_tag: GCC5
-    vm_image: ubuntu-latest
+    tool_chain_tag: $(tool_chain_tag)
+    vm_image: $(vm_image)
     container_image: ghcr.io/tianocore/containers/fedora-35-build:latest
     install_tools: false

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -13,27 +13,17 @@ resources:
       name: microsoft/mu_devops
       ref: main
 
-trigger:
-- main
-
-pr:
-- main
-
-schedules:
-- cron: "0 8 * * 0,3"   # Sun/Wed at 1AM Pacific
-  displayName: Sun/Wed Build
-  branches:
-    include:
-    - main
-  always: true          # Always build, even if no changes
+variables:
+- group: architectures-x86-64
+- group: tool-chain-windows-visual-studio-latest
 
 jobs:
 - template: Jobs/PrGate.yml@mu_devops
   parameters:
-    arch_list: IA32,X64,AARCH64
+    arch_list: $(arch_list)
     do_ci_build: true
     do_ci_setup: false
     packages: IpmiFeaturePkg
     target_list: DEBUG,RELEASE,NO-TARGET,NOOPT
-    tool_chain_tag: VS2022
-    vm_image: windows-2022
+    tool_chain_tag: $(tool_chain_tag)
+    vm_image: $(vm_image)

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -14,7 +14,7 @@ resources:
       ref: main
 
 variables:
-- group: architectures-x86-64
+- group: architectures-arm64-x86-64
 - group: tool-chain-windows-visual-studio-latest
 
 jobs:


### PR DESCRIPTION
- Triggers and schedules will be set in pipeline definitions
- Variable groups are used to centralize common settings

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>