### PR TITLE
Add support for CMOS clear in module and library

### DIFF
--- a/IpmiFeaturePkg/Include/Library/IpmiBootOptionLib.h
+++ b/IpmiFeaturePkg/Include/Library/IpmiBootOptionLib.h
@@ -51,4 +51,19 @@ IpmiGetBootDevice (
   OUT IPMI_BOOT_OPTION_SELECTOR  *Selector
   );
 
+/**
+  Checks if the CMOS clear bit is set in the IPMI boot options.
+
+  @param[out]  ClearCmos    TRUE if the CMOS clear bit is set, FALSE otherwise.
+
+  @retval     EFI_SUCCESS   The CMOS bit was successfully checked.
+  @retval     EFI_NOT_READY The boot option set in progress bit is set.
+  @retval     Other         An error was returned by a subroutine.
+**/
+EFI_STATUS
+EFIAPI
+IpmiGetCmosClearOption (
+  OUT BOOLEAN  *ClearCmos
+  );
+
 #endif

--- a/IpmiFeaturePkg/Include/Library/PlatformCmosClearLib.h
+++ b/IpmiFeaturePkg/Include/Library/PlatformCmosClearLib.h
@@ -1,0 +1,25 @@
+/** @file
+  Definitions for the platform CMOS clear library.
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef PLATFORM_CMOS_CLEAR_LIB_H_
+#define PLATFORM_CMOS_CLEAR_LIB_H_
+
+#include <Uefi.h>
+
+/**
+  Implements platform specifics to clear the CMOS.
+
+  @retval   EFI_SUCCESS     CMOS was successfully cleared.
+**/
+EFI_STATUS
+EFIAPI
+PlatformClearCmos (
+  VOID
+  );
+
+#endif

--- a/IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.c
+++ b/IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.c
@@ -1,0 +1,59 @@
+/** @file
+  The DXE implementation of the IPMI CMOS clear module.
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+
+#include <Library/IpmiBootOptionLib.h>
+#include <Library/PlatformCmosClearLib.h>
+
+/**
+  Entry point to the IPMI CMOS Clear DXE module.
+
+  @param[in]    ImageHandle   The handle for this module image.
+  @param[in]    SystemTable   Pointer to the UEFI system table.
+
+  @retval   EFI_SUCCESS           The watchdog timer and callbacks were properly setup.
+  @retval   EFI_PROTOCOL_ERROR    An unexpected Completion Code was returned by IPMI.
+  @retval   Other                 An error was returned by a subroutine.
+**/
+EFI_STATUS
+EFIAPI
+IpmiCmosEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  BOOLEAN     ClearCmos;
+
+  Status = IpmiGetCmosClearOption (&ClearCmos);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to query CMOS clear bit in IPMI boot options! %r\n", __FUNCTION__, Status));
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "CMOS Clear: %d\n", ClearCmos));
+
+  if (ClearCmos) {
+    Status = PlatformClearCmos ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Platform CMOS clear failed! %r\n", __FUNCTION__, Status));
+      return Status;
+    }
+
+    DEBUG ((DEBUG_INFO, "CMOS Cleared, rebooting..\n"));
+    gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
+++ b/IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
@@ -1,0 +1,37 @@
+### @file
+# Component description file for IPMI CMOS clear driver.
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[defines]
+  INF_VERSION          = 1.26
+  BASE_NAME            = IpmiCmosClear
+  FILE_GUID            = 02FF4955-99AD-45A8-98F0-78CBE279D5CE
+  MODULE_TYPE          = DXE_DRIVER
+  VERSION_STRING       = 1.0
+  ENTRY_POINT          = IpmiCmosEntryPoint
+
+[Sources]
+  IpmiCmosClear.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  MemoryAllocationLib
+  UefiLib
+  DebugLib
+  BaseMemoryLib
+  IpmiBootOptionLib
+  PlatformCmosClearLib
+
+[Depex]
+  gIpmiTransportProtocolGuid

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dec
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dec
@@ -31,6 +31,7 @@
   IpmiPlatformLib|Include/Library/IpmiPlatformLib.h
   IpmiWatchdogLib|Include/Library/IpmiWatchdogLib.h
   IpmiBootOptionLib|Include/Library/IpmiBootOptionLib.h
+  PlatformCmosClearLib|Include/Library/PlatformCmosClearLib.h
 
 [Guids]
   gIpmiFeaturePkgTokenSpaceGuid  =  {0xc05283f6, 0xd6a8, 0x48f3, {0x9b, 0x59, 0xfb, 0xca, 0x71, 0x32, 0x0f, 0x12}}

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -53,6 +53,7 @@
   #####################################
   IpmiTransportLib|IpmiFeaturePkg/Library/IpmiTransportLibNull/IpmiTransportLibNull.inf
   IpmiPlatformLib|IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
+  PlatformCmosClearLib|IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
 
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   #######################################
@@ -102,6 +103,8 @@
   IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
   IpmiFeaturePkg/Library/IpmiWatchdogLib/IpmiWatchdogLib.inf
   IpmiFeaturePkg/Library/IpmiBootOptionLib/IpmiBootOptionLib.inf
+  IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
+  IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
 
   # Transport Libraries
   IpmiFeaturePkg/Library/IpmiTransportLibNull/IpmiTransportLibNull.inf

--- a/IpmiFeaturePkg/Library/IpmiBootOptionLib/IpmiBootOptionLib.c
+++ b/IpmiFeaturePkg/Library/IpmiBootOptionLib/IpmiBootOptionLib.c
@@ -20,11 +20,20 @@
 
 #pragma pack(1)
 
-typedef struct _IPMI_GET_BOOT_OPTIONS_RESPONSE_5 {
+typedef struct _IPMI_GET_BOOT_OPTIONS_RESPONSE_HDR {
   UINT8                                      CompletionCode;
   IPMI_GET_BOOT_OPTIONS_PARAMETER_VERSION    ParameterVersion;
   IPMI_GET_BOOT_OPTIONS_PARAMETER_VALID      ParameterValid;
-  IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5     Data;
+} IPMI_GET_BOOT_OPTIONS_RESPONSE_HDR;
+
+typedef struct _IPMI_GET_BOOT_OPTIONS_RESPONSE_0 {
+  IPMI_GET_BOOT_OPTIONS_RESPONSE_HDR        Header;
+  IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_0    Data;
+} IPMI_GET_BOOT_OPTIONS_RESPONSE_0;
+
+typedef struct _IPMI_GET_BOOT_OPTIONS_RESPONSE_5 {
+  IPMI_GET_BOOT_OPTIONS_RESPONSE_HDR        Header;
+  IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5    Data;
 } IPMI_GET_BOOT_OPTIONS_RESPONSE_5;
 
 typedef struct _IPMI_SET_BOOT_OPTIONS_REQUEST_5 {
@@ -38,6 +47,120 @@ typedef struct _IPMI_SET_BOOT_OPTIONS_REQUEST_4 {
 } IPMI_SET_BOOT_OPTIONS_REQUEST_4;
 
 #pragma pack()
+
+/**
+  Retrieves the specified boot options parameter data.
+
+  @param[in]  ParameterSelector   The boot option parameter number.
+  @param[in]  ResponseSize        The expected data response size.
+  @param[out] Response            The response data from the BMC.
+
+  @retval   EFI_SUCCESS           Boot option paramater was successfully retrieved.
+  @retval   EFI_INVALID_PARAMETER Response pointer or size is invalid.
+  @retval   EFI_BAD_BUFFER_SIZE   The buffer returned did not match expected size.
+  @retval   EFI_PROTOCOL_ERROR    The BMC returned a failing completion code.
+  @retval   Other                 An error was returned by a subroutine.
+**/
+EFI_STATUS
+EFIAPI
+IpmiGetBootOption (
+  IN UINT8                                ParameterSelector,
+  IN UINT32                               ResponseSize,
+  OUT IPMI_GET_BOOT_OPTIONS_RESPONSE_HDR  *Response
+  )
+
+{
+  IPMI_GET_BOOT_OPTIONS_REQUEST  Request;
+  UINT32                         DataSize;
+  EFI_STATUS                     Status;
+
+  if ((Response == NULL) ||
+      (ResponseSize < sizeof (IPMI_GET_BOOT_OPTIONS_RESPONSE_HDR)))
+  {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&Request, sizeof (Request));
+  ZeroMem (Response, ResponseSize);
+  Request.ParameterSelector.Bits.ParameterSelector = ParameterSelector;
+
+  DataSize = ResponseSize;
+  Status   = IpmiSubmitCommand (
+               IPMI_NETFN_CHASSIS,
+               IPMI_CHASSIS_GET_SYSTEM_BOOT_OPTIONS,
+               (VOID *)&Request,
+               sizeof (Request),
+               (VOID *)Response,
+               &DataSize
+               );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get IPMI boot options (%d). %r\n", __FUNCTION__, ParameterSelector, Status));
+    return Status;
+  }
+
+  if (DataSize < sizeof (Response->CompletionCode)) {
+    DEBUG ((DEBUG_ERROR, "%a: Response too small for completion code! 0x%x\n", __FUNCTION__, DataSize));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  if (Response->CompletionCode != IPMI_COMP_CODE_NORMAL) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Get system boot options returned failing completion code. 0x%x\n",
+      __FUNCTION__,
+      Response->CompletionCode
+      ));
+
+    return EFI_PROTOCOL_ERROR;
+  }
+
+  if (DataSize < ResponseSize) {
+    DEBUG ((DEBUG_ERROR, "%a: Unexpected response size! 0x%x\n", __FUNCTION__, DataSize));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Checks if the set in progress is active for IPMI boot options.
+
+  @param[out]   SetInProgress   TRUE if set in progress is active, FALSE otherwise.
+
+  @retval   EFI_SUCCESS     Successfully checked the set in progress bit.
+  @retval   Other           Subroutine returned an error.
+**/
+EFI_STATUS
+EFIAPI
+IpmiCheckSetInProgress (
+  OUT BOOLEAN  *SetInProgress
+  )
+{
+  IPMI_GET_BOOT_OPTIONS_RESPONSE_0  Response;
+  EFI_STATUS                        Status;
+
+  ZeroMem (&Response, sizeof (Response));
+  Status = IpmiGetBootOption (
+             IPMI_BOOT_OPTIONS_PARAMETER_SELECTOR_SET_IN_PROGRESS,
+             sizeof (Response),
+             &Response.Header
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (Response.Header.ParameterValid.Bits.ParameterValid != 0) {
+    DEBUG ((DEBUG_INFO, "%a: Boot options parameter 0 invalid.\n", __FUNCTION__));
+    *SetInProgress = FALSE;
+  } else {
+    *SetInProgress = Response.Data.Bits.SetInProgress & BIT0;
+  }
+
+  return EFI_SUCCESS;
+}
 
 /**
   Clears the IPMI boot options boot flags.
@@ -127,6 +250,49 @@ IpmiAcknowledgeBootOption (
   }
 }
 
+EFI_STATUS
+EFIAPI
+IpmiGetBootFlags (
+  OUT IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5  *BootFlags,
+  OUT BOOLEAN                                 *FlagsValid
+  )
+{
+  IPMI_GET_BOOT_OPTIONS_RESPONSE_5  Response;
+  EFI_STATUS                        Status;
+
+  if ((BootFlags == NULL) || (FlagsValid == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *FlagsValid = FALSE;
+  ZeroMem (BootFlags, sizeof (*BootFlags));
+  ZeroMem (&Response, sizeof (Response));
+
+  Status = IpmiGetBootOption (
+             IPMI_BOOT_OPTIONS_PARAMETER_BOOT_FLAGS,
+             sizeof (Response),
+             &Response.Header
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (Response.Header.ParameterValid.Bits.ParameterValid != 0) {
+    DEBUG ((DEBUG_INFO, "%a: Boot options parameter 5 invalid.\n", __FUNCTION__));
+    return EFI_SUCCESS;
+  }
+
+  if (Response.Data.Data1.Bits.BootFlagValid == 0) {
+    DEBUG ((DEBUG_INFO, "%a: Boot options flags not valid.\n", __FUNCTION__));
+    return EFI_SUCCESS;
+  }
+
+  CopyMem (BootFlags, &Response.Data, sizeof (Response.Data));
+  *FlagsValid = TRUE;
+  return EFI_SUCCESS;
+}
+
 /**
   Gets the boot device override provided by the BMC. This function will clear
   the IPMI flags on calling.
@@ -145,90 +311,125 @@ IpmiGetBootDevice (
   OUT IPMI_BOOT_OPTION_SELECTOR  *Selector
   )
 {
-  IPMI_GET_BOOT_OPTIONS_REQUEST     Request;
-  IPMI_GET_BOOT_OPTIONS_RESPONSE_5  Response;
-  EFI_STATUS                        Status;
-  UINT32                            DataSize;
+  IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5  FlagsData;
+  BOOLEAN                                 FlagsValid;
+  EFI_STATUS                              Status;
+  BOOLEAN                                 SetInProgress;
 
   if (Selector == NULL) {
     return EFI_INVALID_PARAMETER;
   }
 
-  *Selector = BootNone;
-  ZeroMem (&Request, sizeof (Request));
-  ZeroMem (&Response, sizeof (Response));
-  Request.ParameterSelector.Bits.ParameterSelector = IPMI_BOOT_OPTIONS_PARAMETER_BOOT_FLAGS;
-  Request.BlockSelector                            = 0;
+  //
+  // Check there is no set in progress.
+  //
 
-  DataSize = sizeof (Response);
-  Status   = IpmiSubmitCommand (
-               IPMI_NETFN_CHASSIS,
-               IPMI_CHASSIS_GET_SYSTEM_BOOT_OPTIONS,
-               (VOID *)&Request,
-               sizeof (Request),
-               (VOID *)&Response,
-               &DataSize
-               );
-
+  SetInProgress = FALSE;
+  Status        = IpmiCheckSetInProgress (&SetInProgress);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to get IPMI boot options. %r\n", __FUNCTION__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to query set in progress! %r\n", __FUNCTION__, Status));
     return Status;
   }
 
-  if (DataSize < sizeof (Response.CompletionCode)) {
-    DEBUG ((DEBUG_ERROR, "%a: Response too small for completion code! 0x%x\n", __FUNCTION__, DataSize));
-    return EFI_BAD_BUFFER_SIZE;
+  if (SetInProgress) {
+    DEBUG ((DEBUG_ERROR, "%a: Boot option set in progress!\n", __FUNCTION__));
+    return EFI_NOT_READY;
   }
 
-  if (Response.CompletionCode != IPMI_COMP_CODE_NORMAL) {
+  *Selector = BootNone;
+  ZeroMem (&FlagsData, sizeof (FlagsData));
+  FlagsValid = FALSE;
+
+  Status = IpmiGetBootFlags (&FlagsData, &FlagsValid);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (FlagsValid) {
+    *Selector =  FlagsData.Data2.Bits.BootDeviceSelector;
     DEBUG ((
-      DEBUG_ERROR,
-      "%a: Get system boot options returned failing completion code. 0x%x\n",
+      DEBUG_INFO,
+      "%a: Boot device override 0x%x. Persistence: %d \n",
       __FUNCTION__,
-      Response.CompletionCode
+      FlagsData.Data2.Bits.BootDeviceSelector,
+      FlagsData.Data1.Bits.PersistentOptions
       ));
 
-    return EFI_PROTOCOL_ERROR;
+    //
+    // Clear the boot flags once this has been read. If the persistence option is
+    // set then this should be skipped.
+    //
+
+    if (FlagsData.Data1.Bits.PersistentOptions == 0) {
+      IpmiClearBootFlags ();
+    }
   }
 
-  if (DataSize < sizeof (Response)) {
-    DEBUG ((DEBUG_ERROR, "%a: Unexpected response size! 0x%x\n", __FUNCTION__, DataSize));
-    return EFI_BAD_BUFFER_SIZE;
-  }
-
-  if (Response.ParameterValid.Bits.ParameterValid != 0) {
-    DEBUG ((DEBUG_INFO, "%a: Boot options parameter 5 invalid.\n", __FUNCTION__));
-    goto Exit;
-  }
-
-  if (Response.Data.Data1.Bits.BootFlagValid == 0) {
-    DEBUG ((DEBUG_INFO, "%a: Boot options flags not valid.\n", __FUNCTION__));
-    goto Exit;
-  }
-
-  *Selector =  Response.Data.Data2.Bits.BootDeviceSelector;
-  DEBUG ((
-    DEBUG_INFO,
-    "%a: Boot device override 0x%x. Persistence: %d \n",
-    __FUNCTION__,
-    Response.Data.Data2.Bits.BootDeviceSelector,
-    Response.Data.Data1.Bits.PersistentOptions
-    ));
-
-  //
-  // Clear the boot flags once this has been read. If the persistence option is
-  // set then this should be skipped.
-  //
-
-  if (Response.Data.Data1.Bits.PersistentOptions == 0) {
-    IpmiClearBootFlags ();
-  }
-
-Exit:
   //
   // Acknowledge the boot options.
   //
 
   IpmiAcknowledgeBootOption ();
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Checks if the CMOS clear bit is set in the IPMI boot options.
+
+  @param[out]  ClearCmos    TRUE if the CMOS clear bit is set, FALSE otherwise.
+
+  @retval     EFI_SUCCESS   The CMOS bit was successfully checked.
+  @retval     EFI_NOT_READY The boot option set in progress bit is set.
+  @retval     Other         An error was returned by a subroutine.
+**/
+EFI_STATUS
+EFIAPI
+IpmiGetCmosClearOption (
+  OUT BOOLEAN  *ClearCmos
+  )
+
+{
+  EFI_STATUS                              Status;
+  IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5  FlagsData;
+  BOOLEAN                                 FlagsValid;
+  BOOLEAN                                 SetInProgress;
+
+  *ClearCmos    = FALSE;
+  SetInProgress = FALSE;
+  //
+  // Check there is no set in progress.
+  //
+
+  Status = IpmiCheckSetInProgress (&SetInProgress);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to query set in progress! %r\n", __FUNCTION__, Status));
+    return Status;
+  }
+
+  if (SetInProgress) {
+    DEBUG ((DEBUG_ERROR, "%a: Boot option set in progress!\n", __FUNCTION__));
+    return EFI_NOT_READY;
+  }
+
+  //
+  // Check the CMOS clear option.
+  //
+
+  Status = IpmiGetBootFlags (&FlagsData, &FlagsValid);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (!FlagsValid) {
+    return EFI_SUCCESS;
+  }
+
+  *ClearCmos = FlagsData.Data2.Bits.CmosClear;
+
+  //
+  // Clear the CMOS flag so that this doesn't occur next boot.
+  //
+
   return EFI_SUCCESS;
 }

--- a/IpmiFeaturePkg/Library/MockIpmi/MockChassis.c
+++ b/IpmiFeaturePkg/Library/MockIpmi/MockChassis.c
@@ -52,6 +52,15 @@ MockIpmiGetSystemBootOptions (
     CopyMem (OptionResponse + 1, &mBootFlags, sizeof (IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5));
     *ResponseSize = sizeof (IPMI_GET_BOOT_OPTIONS_RESPONSE) +
                     sizeof (IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_5);
+  } else if (GetOptionRequest->ParameterSelector.Bits.ParameterSelector == IPMI_BOOT_OPTIONS_PARAMETER_SELECTOR_SET_IN_PROGRESS) {
+    ASSERT (
+      *ResponseSize - sizeof (IPMI_GET_BOOT_OPTIONS_RESPONSE) >=
+      sizeof (IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_0)
+      );
+
+    ZeroMem (OptionResponse + 1, sizeof (IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_0));
+    *ResponseSize = sizeof (IPMI_GET_BOOT_OPTIONS_RESPONSE) +
+                    sizeof (IPMI_BOOT_OPTIONS_RESPONSE_PARAMETER_0);
   } else {
     DEBUG ((DEBUG_ERROR, "%a: Mock boot options only support boot flags!\n", __FUNCTION__));
     OptionResponse->CompletionCode = 0x80; // Spec defined response for unsupported parameter.

--- a/IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.c
+++ b/IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.c
@@ -1,0 +1,26 @@
+/** @file
+  NULL implementation of the IPMI platform library.
+
+  Copyright (c) Microsoft Corporation
+  PDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PlatformCmosClearLib.h>
+
+/**
+  Implements platform specifics to clear the CMOS.
+
+  @retval   EFI_SUCCESS     CMOS was successfully cleared.
+**/
+EFI_STATUS
+EFIAPI
+PlatformClearCmos (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
+++ b/IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
@@ -1,0 +1,23 @@
+## @file
+# The NULL implementation of the platform CMOS clear library
+#
+# Copyright (c) Microsoft Corporation.
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PlatformCmosClearLibNull
+  FILE_GUID                      = CC4DC596-AC74-4B37-B86D-A7C6B5031A57
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PlatformCmosClearLib
+
+[sources]
+  PlatformCmosClearLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  DebugLib

--- a/IpmiFeaturePkg/Test/UnitTest/BootOptionUnitTest/BootOptionUnitTest.c
+++ b/IpmiFeaturePkg/Test/UnitTest/BootOptionUnitTest/BootOptionUnitTest.c
@@ -182,6 +182,61 @@ TestGetBootOptionPersistance (
 }
 
 /**
+  Tests retrieving the IPMI boot option CMOS clear bit.
+
+  @param[in]  Context             UNUSED
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+TestGetBootOptionCmosClear (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+
+{
+  BOOLEAN     CmosClear;
+  EFI_STATUS  Status;
+
+  //
+  // Ensure valid bit is respected.
+  //
+
+  mBootFlags.Data1.Bits.BootFlagValid = 0;
+  mBootFlags.Data2.Bits.CmosClear     = 1;
+  CmosClear                           = TRUE;
+  Status                              = IpmiGetCmosClearOption (&CmosClear);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_FALSE (CmosClear);
+
+  //
+  // Ensure valid bit is respected.
+  //
+
+  mBootFlags.Data1.Bits.BootFlagValid = 1;
+  mBootFlags.Data2.Bits.CmosClear     = 0;
+  CmosClear                           = TRUE;
+  Status                              = IpmiGetCmosClearOption (&CmosClear);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_FALSE (CmosClear);
+
+  //
+  // Ensure valid bit is respected.
+  //
+
+  mBootFlags.Data1.Bits.BootFlagValid = 1;
+  mBootFlags.Data2.Bits.CmosClear     = 1;
+  CmosClear                           = FALSE;
+  Status                              = IpmiGetCmosClearOption (&CmosClear);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_TRUE (CmosClear);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
   Initializes and configures the SEL library tests.
 
   @retval  EFI_SUCCESS           All test cases were dispatched.
@@ -225,6 +280,7 @@ BootOptionTestMain (
   AddTestCase (BootOptionTests, "Tests retrieving invalid boot flags", "TestGetBootOptionInvalid", TestGetBootOptionInvalid, NULL, ResetTestState, NULL);
   AddTestCase (BootOptionTests, "Tests retrieving boot flags", "TestGetBootOptionNoPersistance", TestGetBootOptionNoPersistance, NULL, ResetTestState, NULL);
   AddTestCase (BootOptionTests, "Tests retrieving persistent boot flags", "TestGetBootOptionPersistance", TestGetBootOptionPersistance, NULL, ResetTestState, NULL);
+  AddTestCase (BootOptionTests, "Tests retrieving persistent boot flags", "TestGetBootOptionCmosClear", TestGetBootOptionCmosClear, NULL, ResetTestState, NULL);
 
   Status = RunAllTestSuites (Framework);
 


### PR DESCRIPTION
- Refactor boot option library for more functionality
- Add routine to boot option lib for querying CMOS clear bit
- Add module to check CMOS clear, invoke platform library, and reset
- Add NULL implementation of the platform CMOS clear library.