### PR TITLE
Added static for non-public functions in library

### DIFF
--- a/IpmiFeaturePkg/Library/IpmiSelLib/IpmiSelLib.c
+++ b/IpmiFeaturePkg/Library/IpmiSelLib/IpmiSelLib.c
@@ -48,6 +48,7 @@ STATIC_ASSERT (
 
   @retval     EFI_STATUS best representing the completion code.
 **/
+STATIC
 EFI_STATUS
 EFIAPI
 IpmiCompCodeToEfiStatus (
@@ -107,6 +108,7 @@ IpmiCompCodeToEfiStatus (
   @retval   EFI_PROTOCOL_ERROR  Unexpected result size.
   @retval   Other               The IPMI base library returned an error.
 **/
+STATIC
 EFI_STATUS
 EFIAPI
 IpmiAddSelEntry (


### PR DESCRIPTION
IpmiSelLib contained two functions without static identifiers, meaning they were available outside of the library.
The two functions are meant to be used internally to the library only.

Added static identifiers to IpmiCompCodeToEfiStatus and IpmiAddSelEntry 

