### PR TITLE
Use RFC4122 foramt for IpmiGetSystemGuid 

### DIFF
--- a/IpmiFeaturePkg/Include/IpmiFeature.h
+++ b/IpmiFeaturePkg/Include/IpmiFeature.h
@@ -14,13 +14,30 @@
 
 #pragma pack(1)
 
-// Structure definition for NetApp function IPMI_APP_GET_SYSTEM_GUID
+//
+// In IPMI, GUID are stored least-significant byte first.
+// The order of fields are the reverse of convention described in [RFC4122].
+// Note: This definition is used for both the IPMI_APP_GET_SYSTEM_GUID
+// and IPMI_APP_GET_DEVICE_GUID.
+//
 typedef struct {
-  UINT8    CompletionCode;
-  UINT8    Guid[16];
+  UINT8     Data4[8];
+  UINT16    Data3;
+  UINT16    Data2;
+  UINT32    Data1;
+} IPMI_GUID;
+
+//
+// Structure definition for NetApp function IPMI_APP_GET_SYSTEM_GUID
+//
+typedef struct {
+  UINT8        CompletionCode;
+  IPMI_GUID    Guid;
 } IPMI_GET_SYSTEM_GUID_RESPONSE;
 
+//
 // Structure definitions for NetApp Function IPMI_APP_GET_SYSTEM_INTERFACE_CAPABILITIES
+//
 typedef enum {
   GetSystemInterfaceTypeSsif = 0,
   GetSystemInterfaceTypeKcs,

--- a/IpmiFeaturePkg/Include/Library/IpmiCommandLib.h
+++ b/IpmiFeaturePkg/Include/Library/IpmiCommandLib.h
@@ -254,7 +254,7 @@ IpmiGetSdr (
 EFI_STATUS
 EFIAPI
 IpmiGetSystemGuid (
-  OUT EFI_GUID  *SystemGuid
+  OUT IPMI_GUID  *SystemGuid
   );
 
 EFI_STATUS

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnApp.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnApp.c
@@ -255,7 +255,7 @@ IpmiSendMessage (
 EFI_STATUS
 EFIAPI
 IpmiGetSystemGuid (
-  OUT EFI_GUID  *SystemGuid
+  OUT IPMI_GUID  *IpmiSystemGuid
   )
 {
   EFI_STATUS  Status;
@@ -266,7 +266,7 @@ IpmiGetSystemGuid (
   IPMI_GET_SYSTEM_GUID_RESPONSE  GuidResponse;
 
   Status = EFI_INVALID_PARAMETER;
-  if (SystemGuid != NULL) {
+  if (IpmiSystemGuid != NULL) {
     DataSize = sizeof (IPMI_GET_DEVICE_GUID_RESPONSE);
 
     Status = IpmiSubmitCommand (
@@ -278,7 +278,7 @@ IpmiGetSystemGuid (
                &DataSize
                );
     if (!EFI_ERROR (Status)) {
-      CopyMem ((VOID *)SystemGuid, (VOID *)(GuidResponse.Guid), sizeof (EFI_GUID));
+      CopyMem ((VOID *)IpmiSystemGuid, (VOID *)(&GuidResponse.Guid), sizeof (IPMI_GUID));
     }
   }
 


### PR DESCRIPTION
IPMI specification calls out reverse GUID format RFC4122 for transmitting data from the Get System Guid and Get Device Guid formats.

Added data structure defining the format, and modified IpmiGetSystemGuid to return that structure instead of an EFI_GUID. 