### PR TITLE
Updating BMC ACPI power state.

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -3,6 +3,12 @@
 #
 # IMPORTANT: Only use labels defined in the .github/Labels.yml file in this repo.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/.github/workflows/label-issues/file-paths.yml
+++ b/.github/workflows/label-issues/file-paths.yml
@@ -1,5 +1,11 @@
 # Specifies labels to apply to issues and pull requests based on file path patterns in Project Mu repositories.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/.github/workflows/label-issues/regex-pull-requests.yml
+++ b/.github/workflows/label-issues/regex-pull-requests.yml
@@ -1,5 +1,11 @@
 # Specifies labels to apply to pull requests in Project Mu repositories based on regular expressions.
 #
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.c
+++ b/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.c
@@ -9,6 +9,7 @@
 #include <Library/SmmServicesTableLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IpmiBaseLib.h>
+#include <Library/BaseMemoryLib.h>
 #include <IndustryStandard/IpmiNetFnApp.h>
 
 #include <Protocol/SmmExitBootServices.h>
@@ -34,6 +35,7 @@ SetBmcAcpiPowerState (
   UINT8                              CompletionCode;
   UINT32                             DataSize;
 
+  ZeroMem (&SetAcpiPowerState, sizeof (SetAcpiPowerState));
   SetAcpiPowerState.SystemPowerState.Bits.StateChange = 1;
   SetAcpiPowerState.SystemPowerState.Bits.PowerState  = SystemPowerState;
   SetAcpiPowerState.DevicePowerState.Bits.StateChange = 1;

--- a/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.c
+++ b/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.c
@@ -1,0 +1,185 @@
+/** @file
+    BmcAcpiPowerStateSmm.c
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+**/
+
+#include <PiSmm.h>
+#include <Library/SmmServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IpmiBaseLib.h>
+#include <IndustryStandard/IpmiNetFnApp.h>
+
+#include <Protocol/SmmExitBootServices.h>
+#include <Protocol/SmmSxDispatch2.h>
+
+/**
+  Send IPMI command to set ACPI power state to BMC.
+
+  @param[in]  SystemPowerState        System Power State enumeration
+  @param[in]  DevicePowerState        Device Power State enumeration
+
+  @retval EFI_SUCCESS     Set ACPI power state to BMC successfully.
+  @retval Other           Failed to set ACPI power state to BMC.
+**/
+EFI_STATUS
+SetBmcAcpiPowerState (
+  IN  UINT8  SystemPowerState,
+  IN  UINT8  DevicePowerState
+  )
+{
+  EFI_STATUS                         Status;
+  IPMI_SET_ACPI_POWER_STATE_REQUEST  SetAcpiPowerState;
+  UINT8                              CompletionCode;
+  UINT32                             DataSize;
+
+  SetAcpiPowerState.SystemPowerState.Bits.StateChange = 1;
+  SetAcpiPowerState.SystemPowerState.Bits.PowerState  = SystemPowerState;
+  SetAcpiPowerState.DevicePowerState.Bits.StateChange = 1;
+  SetAcpiPowerState.DevicePowerState.Bits.PowerState  = DevicePowerState;
+
+  DataSize = sizeof (CompletionCode);
+  Status   = IpmiSubmitCommand (
+               IPMI_NETFN_APP,
+               IPMI_APP_SET_ACPI_POWERSTATE,
+               (UINT8 *)&SetAcpiPowerState,
+               sizeof (SetAcpiPowerState),
+               &CompletionCode,
+               &DataSize
+               );
+
+  DEBUG ((DEBUG_ERROR, "[%a] --- %r\n", __FUNCTION__, Status));
+
+  return Status;
+}
+
+/**
+  Main entry point for an SMM handler dispatch or communicate-based callback.
+
+  @param[in]     DispatchHandle  The unique handle assigned to this handler by SmiHandlerRegister().
+  @param[in]     Context         Points to an optional handler context which was specified when the
+                                 handler was registered.
+  @param[in,out] CommBuffer      A pointer to a collection of data in memory that will
+                                 be conveyed from a non-SMM environment into an SMM environment.
+  @param[in,out] CommBufferSize  The size of the CommBuffer.
+
+  @retval EFI_SUCCESS            Update ACPI power state to BMC successfully.
+**/
+EFI_STATUS
+EFIAPI
+BmcAcpiPowerStateS5EntryCallBack (
+  IN           EFI_HANDLE  DispatchHandle,
+  IN     CONST VOID        *Context         OPTIONAL,
+  IN OUT       VOID        *CommBuffer      OPTIONAL,
+  IN OUT       UINTN       *CommBufferSize  OPTIONAL
+  )
+{
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "[%a] --- Start\n", __FUNCTION__));
+
+  Status = SetBmcAcpiPowerState (IPMI_SYSTEM_POWER_STATE_S5_G2, IPMI_DEVICE_POWER_STATE_D3);
+
+  DEBUG ((DEBUG_INFO, "[%a] --- End %r\n", __FUNCTION__, Status));
+
+  return Status;
+}
+
+/**
+  Notification for installation of SMM Exit Boot Service protocol
+  which indicates system booted to OS or runtime.
+
+  @param[in] Protocol   Points to the protocol's unique identifier.
+  @param[in] Interface  Points to the interface instance.
+  @param[in] Handle     The handle on which the interface was installed.
+
+  @retval EFI_SUCCESS   Update ACPI power state to BMC successfully.
+**/
+EFI_STATUS
+EFIAPI
+BmcAcpiPowerStateExitBootServicesCallback (
+  IN      CONST EFI_GUID  *Protocol,
+  IN      VOID            *Interface,
+  IN      EFI_HANDLE      Handle
+  )
+{
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "[%a] --- Start\n", __FUNCTION__));
+
+  Status = SetBmcAcpiPowerState (IPMI_SYSTEM_POWER_STATE_S0_G0, IPMI_DEVICE_POWER_STATE_D0);
+
+  DEBUG ((DEBUG_INFO, "[%a] --- End %r\n", __FUNCTION__, Status));
+  return Status;
+}
+
+/**
+  This is the standard driver entry point.
+  This function will create event of ExitBootService.
+
+  @param ImageHandle      Handle for the image of this driver.
+  @param SystemTable      Pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS     Action is performed successfully.
+  @retval Other           Error occurred during execution.
+**/
+EFI_STATUS
+EFIAPI
+InitializeBmcAcpiPowerStateSmm (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                     Status = EFI_SUCCESS;
+  EFI_SMM_SX_DISPATCH2_PROTOCOL  *SxDispatch;
+  EFI_SMM_SX_REGISTER_CONTEXT    EntryRegisterContext;
+  EFI_HANDLE                     S5EntryHandle;
+  VOID                           *Registration;
+
+  DEBUG ((DEBUG_INFO, "[%a] --- Start\n", __FUNCTION__));
+
+  if (gSmst == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Locate SmmSxDispatch2 protocol.
+  //
+  Status = gSmst->SmmLocateProtocol (
+                    &gEfiSmmSxDispatch2ProtocolGuid,
+                    NULL,
+                    (VOID **)&SxDispatch
+                    );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] SmmLocateProtocol(gEfiSmmSxDispatch2ProtocolGuid): %r\n", __FUNCTION__, Status));
+    return Status;
+  }
+
+  //
+  // Register a S5 entry callback function
+  //
+  EntryRegisterContext.Type  = SxS5;
+  EntryRegisterContext.Phase = SxEntry;
+  Status                     = SxDispatch->Register (
+                                             SxDispatch,
+                                             BmcAcpiPowerStateS5EntryCallBack,
+                                             &EntryRegisterContext,
+                                             &S5EntryHandle
+                                             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] SxDispatch(SmmS5EntryCallBack): %r\n", __FUNCTION__, Status));
+  }
+
+  //
+  // Register a SMM exit boot service callback
+  //
+  Status = gSmst->SmmRegisterProtocolNotify (
+                    &gEdkiiSmmExitBootServicesProtocolGuid,
+                    BmcAcpiPowerStateExitBootServicesCallback,
+                    &Registration
+                    );
+
+  DEBUG ((DEBUG_INFO, "[%a] --- End %r\n", __FUNCTION__, Status));
+
+  return Status;
+}

--- a/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.c
+++ b/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.c
@@ -2,6 +2,7 @@
     BmcAcpiPowerStateSmm.c
 
     Copyright (c) Microsoft Corporation. All rights reserved.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <PiSmm.h>

--- a/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
+++ b/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
@@ -1,0 +1,42 @@
+## @file BmcAcpiPowerStateSmm.inf
+#
+# INF description file for BmcAcpiPowerState SMM driver
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+##
+
+[Defines]
+  INF_VERSION              = 0x00010005
+  BASE_NAME                = BmcAcpiPowerStateSmm
+  FILE_GUID                = DDB0D654-B9C8-45F0-8A8A-D63474AF3210
+  MODULE_TYPE              = DXE_SMM_DRIVER
+  PI_SPECIFICATION_VERSION = 0x0001000A
+  ENTRY_POINT              = InitializeBmcAcpiPowerStateSmm
+
+[Sources]
+  BmcAcpiPowerStateSmm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec  
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  SmmServicesTableLib
+  DebugLib
+  IpmiBaseLib
+
+[Protocols]
+  gEfiSmmSxDispatch2ProtocolGuid
+  gEdkiiSmmExitBootServicesProtocolGuid
+
+[Guids]
+
+[Pcd]
+
+[Depex]
+   gEfiSmmSxDispatch2ProtocolGuid AND
+   gIpmiTransportProtocolGuid

--- a/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
+++ b/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
@@ -3,6 +3,7 @@
 # INF description file for BmcAcpiPowerState SMM driver
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
 [Defines]

--- a/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
+++ b/IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
@@ -29,6 +29,7 @@
   SmmServicesTableLib
   DebugLib
   IpmiBaseLib
+  BaseMemoryLib
 
 [Protocols]
   gEfiSmmSxDispatch2ProtocolGuid

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -95,6 +95,7 @@
   IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
   IpmiFeaturePkg/GenericIpmi/Dxe/DxeGenericIpmi.inf
   IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
+  IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf  
   IpmiFeaturePkg/IpmiFru/IpmiFru.inf
   IpmiFeaturePkg/SolStatus/SolStatus.inf
   IpmiFeaturePkg/Library/IpmiSelLib/IpmiSelLib.inf


### PR DESCRIPTION

## Description

Add ExitBootService event and S5 SMI handler for updating BMC ACPI power state.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. Power on SUT.
2. Check if SUT boot into Shell.
3. Change ACPI Power State to S3/D3.
  ipmitool -H 10.134.67.13 -U admin -P admin -I lanplus raw 0x6 0x6 0x83 0x83
  ipmitool -H 10.134.67.13 -U admin -P admin -I lanplus raw 0x6 0x7
   03* 03**
4. Boot into Windows.
5. Check if state has been changed to S0/D0.
  ipmitool -H 10.134.67.13 -U admin -P admin -I lanplus raw 0x6 0x7
   00* 00**
6. Shutdown SUT.
7. Check if state has been changed to S5/D3.
  ipmitool -H 10.134.67.13 -U admin -P admin -I lanplus raw 0x6 0x7
   05* 03**

> Note:
> *00h  S0 / G0   working
> *03h  S3        typically equates to “suspend-to-RAM”
> *05h  S5 / G2   soft off
> 
> **00h  D0
> **03h  D3

## Integration Instructions

N/A
