### PR TITLE
Add Ipmi Sensor commands Set Threshold and Get Threshold. 

### DIFF
--- a/IpmiFeaturePkg/Include/Library/IpmiCommandLib.h
+++ b/IpmiFeaturePkg/Include/Library/IpmiCommandLib.h
@@ -265,4 +265,18 @@ IpmiGetSystemInterfaceCapabilities (
   IN OUT UINT32                                         *ResponseDataSize
   );
 
+EFI_STATUS
+EFIAPI
+IpmiSetSensorThreshold (
+  IN IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA  *SetSensorThresholdRequestData,
+  OUT UINT8                                         *CompletionCode
+  );
+
+EFI_STATUS
+EFIAPI
+IpmiGetSensorThreshold (
+  IN UINT8                                            SensorNumber,
+  OUT IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA  *GetSensorThresholdResponse
+  );
+
 #endif

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLib.inf
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLib.inf
@@ -20,6 +20,7 @@
   IpmiCommandLibNetFnTransport.c
   IpmiCommandLibNetFnChassis.c
   IpmiCommandLibNetFnStorage.c
+  IpmiCommandLibNetFnSensor.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
@@ -1,0 +1,83 @@
+/** @file
+  IPMI Command - NetFnSensor.
+
+  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IpmiBaseLib.h>
+
+#include <IpmiFeature.h>
+
+/**
+ * @brief Query the BMC for the information about the system interface
+ *
+ * @param SetSensorThresholdRequestData The filled out Set Sensor Threshold command structure
+ * @param CompletionCode Pointer to a buffer for returning the completion code
+ * @return EFI_STATUS
+ */
+EFI_STATUS
+EFIAPI
+IpmiSetSensorThreshold (
+  IN IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA  *SetSensorThresholdRequestData,
+  OUT UINT8                                         *CompletionCode
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      ResponseDataSize;
+
+  Status = EFI_INVALID_PARAMETER;
+
+  if ((SetSensorThresholdRequestData != NULL) && (CompletionCode != NULL)) {
+    ResponseDataSize = sizeof (*CompletionCode);
+
+    Status = IpmiSubmitCommand (
+               IPMI_NETFN_SENSOR_EVENT,
+               IPMI_SENSOR_SET_SENSOR_THRESHOLDS,
+               (UINT8 *)SetSensorThresholdRequestData,
+               sizeof (*SetSensorThresholdRequestData),
+               (UINT8 *)&CompletionCode,
+               &ResponseDataSize
+               );
+  }
+
+  return Status;
+}
+
+/**
+ * @brief Query the BMC for the information about the system interface
+ *
+ * @param SensorNumber The interface that is being queried (GET_SYSTEM_INTEFACE_INTERFACE_TYPE)
+ * @param GetSensorThresholdResponse Pointer to a buffer for returning the response data.
+ * @return EFI_STATUS
+ */
+EFI_STATUS
+EFIAPI
+IpmiGetSensorThreshold (
+  IN UINT8                                            SensorNumber,
+  OUT IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA  *GetSensorThresholdResponse
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      ResponseDataSize;
+
+  Status = EFI_INVALID_PARAMETER;
+  if (GetSensorThresholdResponse != NULL) {
+    ResponseDataSize = sizeof (IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA);
+
+    ZeroMem (&GetSensorThresholdResponse, sizeof (*GetSensorThresholdResponse));
+
+    Status = IpmiSubmitCommand (
+               IPMI_NETFN_SENSOR_EVENT,
+               IPMI_SENSOR_GET_SENSOR_THRESHOLDS,
+               (UINT8 *)&SensorNumber,
+               sizeof (UINT8),
+               (UINT8 *)&GetSensorThresholdResponse,
+               &ResponseDataSize
+               );
+  }
+
+  return Status;
+}

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
@@ -12,7 +12,7 @@
 #include <IpmiFeature.h>
 
 /**
- * @brief Query the BMC for the information about the system interface
+ * @brief Send the Set Sensor Threshold command for a specified SensorNumber
  *
  * @param SetSensorThresholdRequestData The filled out Set Sensor Threshold command structure
  * @param CompletionCode Pointer to a buffer for returning the completion code
@@ -47,10 +47,10 @@ IpmiSetSensorThreshold (
 }
 
 /**
- * @brief Query the BMC for the information about the system interface
+ * @brief Query the threshold data of the specified SensorNumber.
  *
- * @param SensorNumber The interface that is being queried (GET_SYSTEM_INTEFACE_INTERFACE_TYPE)
- * @param GetSensorThresholdResponse Pointer to a buffer for returning the response data.
+ * @param SensorNumber The unique identifier of the sensor being queried.
+ * @param GetSensorThresholdResponse Pointer to a buffer for returning the threshold response data.
  * @return EFI_STATUS
  */
 EFI_STATUS

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
@@ -43,7 +43,6 @@ IpmiSetSensorThreshold (
                CompletionCode,
                &ResponseDataSize
                );
-
   }
 
   return Status;
@@ -69,6 +68,7 @@ IpmiGetSensorThreshold (
   UINT32      ResponseDataSize;
 
   Status = EFI_INVALID_PARAMETER;
+
   if (GetSensorThresholdResponse != NULL) {
     ResponseDataSize = sizeof (IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA);
 

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
@@ -1,8 +1,8 @@
 /** @file
   IPMI Command - NetFnSensor.
 
-  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
-  SPDX-License-Identifier: BSD-2-Clause-Patent
+  Copyright (c) Microsoft Corporation
+  PDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <Library/BaseMemoryLib.h>

--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnSensor.c
@@ -12,11 +12,13 @@
 #include <IpmiFeature.h>
 
 /**
- * @brief Send the Set Sensor Threshold command for a specified SensorNumber
+ * Send the Set Sensor Threshold command for a specified SensorNumber
  *
- * @param SetSensorThresholdRequestData The filled out Set Sensor Threshold command structure
- * @param CompletionCode Pointer to a buffer for returning the completion code
- * @return EFI_STATUS
+ * @param[in]   SetSensorThresholdRequestData   The filled out Set Sensor Threshold command structure
+ * @param[out]  CompletionCode                  Pointer to a buffer for returning the completion code
+ *
+ * @retval  EFI_SUCCESS
+ * @retval  EFI_INVALID_PARAMETER
  */
 EFI_STATUS
 EFIAPI
@@ -47,11 +49,13 @@ IpmiSetSensorThreshold (
 }
 
 /**
- * @brief Query the threshold data of the specified SensorNumber.
+ * Query the threshold data of the specified SensorNumber.
  *
- * @param SensorNumber The unique identifier of the sensor being queried.
- * @param GetSensorThresholdResponse Pointer to a buffer for returning the threshold response data.
- * @return EFI_STATUS
+ * @param[in]   SensorNumber                The unique identifier of the sensor being queried.
+ * @param[out]  GetSensorThresholdResponse  Pointer to a buffer for returning the threshold response data.
+ *
+ * @retval  EFI_SUCCESS
+ * @retval  EFI_INVALID_PARAMETER
  */
 EFI_STATUS
 EFIAPI

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library~=0.14.0
-edk2-pytool-extensions~=0.21.2
+edk2-pytool-extensions~=0.22.0
 edk2-basetools==0.1.24
 antlr4-python3-runtime==4.12.0
 regex


### PR DESCRIPTION
## Description

Added file IpmiCommandLibNetSensor.c to hold sensor related functions. 
Added functions IpmiSetSensorThreshold and IpmiGetSensorThreshold.


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
n/a

## Integration Instructions
N/A