### PR TITLE
IpmiFeaturePkg/GenericIpmi: Move parameter validation

### DIFF
--- a/IpmiFeaturePkg/GenericIpmi/Common/GenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/Common/GenericIpmi.c
@@ -95,7 +95,7 @@ IpmiPrintCommand (
       DEBUG ((DebugLevel, "\n"));
     }
 
-    DEBUG ((DebugLevel, "%02x ", Data[Index]));
+    DEBUG ((DebugLevel, "%02x ", (Data == NULL) ? 0 : Data[Index]));
   }
 
   DEBUG ((DebugLevel, "\n"));
@@ -140,6 +140,10 @@ IpmiSendCommandInternal (
   UINT8                   RetryCnt;
   UINT8                   Index;
 
+  if ((CommandDataSize > 0) && (CommandData == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   RetryCnt     = PcdGet8 (PcdIpmiCommandMaxReties);
   IpmiInstance = INSTANCE_FROM_SM_IPMI_BMC_THIS (This);
 
@@ -170,10 +174,6 @@ IpmiSendCommandInternal (
     // buffer into the IpmiCommand structure.
     //
     if (CommandDataSize > 0) {
-      if (CommandData == NULL) {
-        return EFI_INVALID_PARAMETER;
-      }
-
       CopyMem (
         IpmiCommand->CommandData,
         CommandData,


### PR DESCRIPTION
## Description

Moves parameter validation in `IpmiSendCommandInternal()` to the
beginning of the function so (1) it is not redundantly checked in
a retry loop and (2) to catch an invalid condition before executing
other function logic.

Also update `IpmiPrintCommand()` to explicitly check for `CommandData`
being `NULL` since it will currently dereference a null pointer if
that pointer variable is `NULL`.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build and code review.

## Integration Instructions

N/A - Code refactor / bug fix

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>