### PR TITLE
IpmiFeaturePkg/GenericIpmi: Fix CodeQL type comparison issue

### DIFF
--- a/IpmiFeaturePkg/GenericIpmi/Common/IpmiInitialize.c
+++ b/IpmiFeaturePkg/GenericIpmi/Common/IpmiInitialize.c
@@ -46,7 +46,7 @@ GetSelfTest (
 {
   EFI_STATUS                      Status;
   UINT32                          DataSize;
-  UINT8                           Index;
+  UINT32                          Index;
   UINT8                           *TempPtr;
   UINT32                          Retries;
   BOOLEAN                         bResultFlag = FALSE;


### PR DESCRIPTION
## Description

**Issue:**

Comparison between `Index` of type `UINT8` and `DataSize` of wider
type `UINT32`.

**Description:**

Comparisons between types of different widths in a loop condition can
cause the loop to behave unexpectedly.

**Resolution:**

Make `Index` a `UINT32` so it is the same width as `DataSize`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CodeQL CI plugin results.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>