### PR TITLE
ci.yaml: add PrEval entry

### DIFF
--- a/IpmiFeaturePkg/IpmiFeaturePkg.ci.yaml
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.ci.yaml
@@ -8,6 +8,9 @@
 ##
 
 {
+    "PrEval": {
+        "DscPath": "IpmiFeaturePkg.dsc",
+    },
     "LicenseCheck": {
         "IgnoreFiles": []
     },


### PR DESCRIPTION
## Description

Adds a PrEval entry to all ci.yaml files to enable the new PrEval Policy 5.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
