### PR TITLE
Implement IpmiPowerRestorePolicy module

### DIFF
--- a/IpmiFeaturePkg/Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
+++ b/IpmiFeaturePkg/Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
@@ -1,0 +1,34 @@
+/** @file
+
+    PlatformPowerRestorePolicyConfigurationLib.h
+
+    Copyright (c) Microsoft Corporation.
+**/
+
+#ifndef PLATFORM_POWER_RESTORE_POLICY_CONFIGURATION_LIB_H_
+#define PLATFORM_POWER_RESTORE_POLICY_CONFIGURATION_LIB_H_
+
+//
+// Power Restore Policy configuration.
+//
+#define  POWER_RESTORE_POLICY_POWER_OFF   0x00
+#define  POWER_RESTORE_POLICY_LAST_STATE  0x01
+#define  POWER_RESTORE_POLICY_POWER_ON    0x02
+#define  POWER_RESTORE_POLICY_NO_CHANGE   0x03  // "Set Power Restore Policy"
+#define  POWER_RESTORE_POLICY_UNKNOWN     0x03  // "Get Chassis Status"
+
+/**
+  Get PowerRestorePolicy
+
+  @param[out] PowerRestorePolicy  The PowerRestorePolicy setting of the platform
+
+  @retval EFI_INVALID_PARAMETER      The input parameter is invalid.
+  @retval EFI_SUCCESS                Get PowerRestorePolicy successfully.
+**/
+EFI_STATUS
+EFIAPI
+GetPowerRestorePolicy (
+  OUT UINT8  *PowerRestorePolicy
+  );
+
+#endif //#ifdef PLATFORM_POWER_RESTORE_POLICY_CONFIGURATION_LIB_H_

--- a/IpmiFeaturePkg/Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
+++ b/IpmiFeaturePkg/Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
@@ -1,6 +1,6 @@
-/** @file
+/** @file PlatformPowerRestorePolicyConfigurationLib.h
 
-    PlatformPowerRestorePolicyConfigurationLib.h
+    Platform Power Restore Policy Configuration Library interface
 
     Copyright (c) Microsoft Corporation.
     SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -10,7 +10,7 @@
 #define PLATFORM_POWER_RESTORE_POLICY_CONFIGURATION_LIB_H_
 
 //
-// Power Restore Policy configuration.
+// Power Restore Policy definition from IPMI Spec.
 //
 #define  POWER_RESTORE_POLICY_POWER_OFF   0x00
 #define  POWER_RESTORE_POLICY_LAST_STATE  0x01
@@ -23,8 +23,8 @@
 
   @param[out] PowerRestorePolicy  The PowerRestorePolicy setting of the platform
 
-  @retval EFI_INVALID_PARAMETER      The input parameter is invalid.
-  @retval EFI_SUCCESS                Get PowerRestorePolicy successfully.
+  @retval EFI_INVALID_PARAMETER   The input parameter is invalid.
+  @retval EFI_SUCCESS             Get PowerRestorePolicy successfully.
 **/
 EFI_STATUS
 EFIAPI

--- a/IpmiFeaturePkg/Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
+++ b/IpmiFeaturePkg/Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
@@ -3,6 +3,7 @@
     PlatformPowerRestorePolicyConfigurationLib.h
 
     Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #ifndef PLATFORM_POWER_RESTORE_POLICY_CONFIGURATION_LIB_H_

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dec
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dec
@@ -31,6 +31,7 @@
   IpmiWatchdogLib|Include/Library/IpmiWatchdogLib.h
   IpmiBootOptionLib|Include/Library/IpmiBootOptionLib.h
   PlatformCmosClearLib|Include/Library/PlatformCmosClearLib.h
+  PlatformPowerRestorePolicyConfigurationLib|Include/Library/PlatformPowerRestorePolicyConfigurationLib.h
 
 [Guids]
   gIpmiFeaturePkgTokenSpaceGuid  =  {0xc05283f6, 0xd6a8, 0x48f3, {0x9b, 0x59, 0xfb, 0xca, 0x71, 0x32, 0x0f, 0x12}}

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -54,6 +54,7 @@
   IpmiTransportLib|IpmiFeaturePkg/Library/IpmiTransportLibNull/IpmiTransportLibNull.inf
   IpmiPlatformLib|IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
   PlatformCmosClearLib|IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
+  PlatformPowerRestorePolicyConfigurationLib|IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
 
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   #######################################
@@ -109,6 +110,7 @@
   IpmiFeaturePkg/SpmiTable/SpmiTable.inf
   IpmiFeaturePkg/IpmiSmbios/IpmiSmbios.inf
   IpmiFeaturePkg/IpmiFru/IpmiFru.inf
+  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
   IpmiFeaturePkg/SolStatus/SolStatus.inf
   IpmiFeaturePkg/Library/IpmiSelLib/IpmiSelLib.inf
   IpmiFeaturePkg/IpmiWatchdog/Pei/IpmiWatchdogPei.inf
@@ -118,6 +120,7 @@
   IpmiFeaturePkg/Library/IpmiBootOptionLib/IpmiBootOptionLib.inf
   IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
   IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
+  IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
 
   # Transport Libraries
   IpmiFeaturePkg/Library/IpmiTransportLibNull/IpmiTransportLibNull.inf

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.c
@@ -1,12 +1,12 @@
-/** @file
-    IpmiPowerRestorePolicy.c
+/** @file IpmiPowerRestorePolicy.c
 
-    Copyright (c) Microsoft Corporation.
+  This file implementing a driver entrypoint that configure Power Restore Policy via IPMI command
+
+  Copyright (c) Microsoft Corporation.
+  PDX-License-Identifier: BSD-2-Clause-Patent
+
 **/
 
-//
-// Common header files
-//
 #include <PiPei.h>
 #include <Library/DebugLib.h>
 #include <Library/IpmiCommandLib.h>

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.c
@@ -1,0 +1,89 @@
+/** @file
+    IpmiPowerRestorePolicy.c
+
+    Copyright (c) Microsoft Corporation.
+**/
+
+//
+// Common header files
+//
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/IpmiCommandLib.h>
+#include <Library/PlatformPowerRestorePolicyConfigurationLib.h>
+
+/**
+  Synchronize BMC power restore policy setting with config data.
+
+  @param  FileHandle      Handle of the file
+  @param  PeiServices     List of possible PEI Services.
+
+  @return EFI_SUCCESS     Synchronize successfully or policy is consistent between BMC and platform.
+  @return Others          Synchronize failed
+**/
+EFI_STATUS
+EFIAPI
+IpmiPowerRestorePolicyEntry (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  EFI_STATUS                              Status;
+  IPMI_GET_CHASSIS_STATUS_RESPONSE        ChassisStatusRespData;
+  UINT8                                   CurrentPowerRestorePolicy;
+  UINT8                                   PlatformPowerRestorePolicy;
+  IPMI_SET_POWER_RESTORE_POLICY_REQUEST   SetRestorePolicyRequest;
+  IPMI_SET_POWER_RESTORE_POLICY_RESPONSE  SetRestorePolicyResponse;
+
+  //
+  // Get current power restore policy
+  //
+  Status = IpmiGetChassisStatus (&ChassisStatusRespData);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] - IpmiGetChassisStatus: %r\n", __FUNCTION__, Status));
+    CurrentPowerRestorePolicy = POWER_RESTORE_POLICY_UNKNOWN;
+  } else {
+    CurrentPowerRestorePolicy = (ChassisStatusRespData.CurrentPowerState >> 5) & 0x3; // [6:5] - power restore policy
+  }
+
+  DEBUG ((DEBUG_INFO, "[%a] - CurrentPowerRestorePolicy: 0x%x\n", __FUNCTION__, CurrentPowerRestorePolicy));
+
+  //
+  // Get platform power restore policy
+  //
+  Status = GetPowerRestorePolicy (&PlatformPowerRestorePolicy);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] - GetPowerRestorePolicy: %r\n", __FUNCTION__, Status));
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "[%a] - PlatformPowerRestorePolicy: 0x%x\n", __FUNCTION__, PlatformPowerRestorePolicy));
+
+  if ( PlatformPowerRestorePolicy == CurrentPowerRestorePolicy) {
+    // Just return if policy is consistent between BMC and platform.
+    DEBUG ((DEBUG_ERROR, "[%a] - Current Power Restore Policy is consistent with platform setting\n", __FUNCTION__));
+    return EFI_SUCCESS;
+  }
+
+  //
+  // If platform setting is not POWER_RESTORE_POLICY_NO_CHANGE, then sync BMC
+  //
+  if (PlatformPowerRestorePolicy != POWER_RESTORE_POLICY_NO_CHANGE) {
+    SetRestorePolicyRequest.PowerRestorePolicy.Bits.PowerRestorePolicy = PlatformPowerRestorePolicy;
+    // Set reserved bits to 0
+    SetRestorePolicyRequest.PowerRestorePolicy.Bits.Reserved = 0;
+    // Update IPMI power restore policy
+    Status = IpmiSetPowerRestorePolicy (&SetRestorePolicyRequest, &SetRestorePolicyResponse);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "[%a] - IpmiSetPowerRestorePolicy status: %r\n", __FUNCTION__, Status));
+      return Status;
+    } else if (SetRestorePolicyResponse.CompletionCode != 0) {
+      DEBUG ((DEBUG_INFO, "[%a] - IpmiSetPowerRestorePolicy completion code: %r\n", __FUNCTION__, SetRestorePolicyResponse.CompletionCode));
+      return EFI_UNSUPPORTED; // per spec
+    }
+  }
+
+  return EFI_SUCCESS;
+}

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.c
@@ -3,7 +3,7 @@
   This file implementing a driver entrypoint that configure Power Restore Policy via IPMI command
 
   Copyright (c) Microsoft Corporation.
-  PDX-License-Identifier: BSD-2-Clause-Patent
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
@@ -15,11 +15,11 @@
 /**
   Configure Power Restore Policy via IPMI
 
-  @param  FileHandle      Handle of the file
-  @param  PeiServices     List of possible PEI Services.
+  @param[in]  FileHandle      Handle of the file
+  @param[in]  PeiServices     List of possible PEI Services.
 
-  @return EFI_SUCCESS     Power Restore Policy is configured to expected setting successfully.
-  @return Others          Failed to configure Power Restore Policy
+  @return EFI_SUCCESS         Power Restore Policy is configured to expected setting successfully.
+  @return Others              Failed to configure Power Restore Policy
 **/
 EFI_STATUS
 EFIAPI
@@ -47,7 +47,7 @@ IpmiPowerRestorePolicyEntry (
     CurrentPowerRestorePolicy = (ChassisStatusRespData.CurrentPowerState >> 5) & 0x3; // [6:5] - power restore policy
   }
 
-  DEBUG ((DEBUG_INFO, "[%a] - CurrentPowerRestorePolicy: 0x%x\n", __FUNCTION__, CurrentPowerRestorePolicy));
+  DEBUG ((DEBUG_VERBOSE, "[%a] - CurrentPowerRestorePolicy: 0x%x\n", __FUNCTION__, CurrentPowerRestorePolicy));
 
   //
   // Get platform power restore policy setting
@@ -59,11 +59,11 @@ IpmiPowerRestorePolicyEntry (
     return Status;
   }
 
-  DEBUG ((DEBUG_INFO, "[%a] - PlatformPowerRestorePolicy: 0x%x\n", __FUNCTION__, PlatformPowerRestorePolicy));
+  DEBUG ((DEBUG_VERBOSE, "[%a] - PlatformPowerRestorePolicy: 0x%x\n", __FUNCTION__, PlatformPowerRestorePolicy));
 
   if ( PlatformPowerRestorePolicy == CurrentPowerRestorePolicy) {
     // Just return if CurrentPowerRestorePolicy the same with PlatformPowerRestorePolicy
-    DEBUG ((DEBUG_ERROR, "[%a] - Current Power Restore Policy is consistent with platform setting\n", __FUNCTION__));
+    DEBUG ((DEBUG_VERBOSE, "[%a] - Current Power Restore Policy is consistent with platform setting\n", __FUNCTION__));
     return EFI_SUCCESS;
   }
 
@@ -78,7 +78,7 @@ IpmiPowerRestorePolicyEntry (
       DEBUG ((DEBUG_ERROR, "[%a] - IpmiSetPowerRestorePolicy status: %r\n", __FUNCTION__, Status));
       return Status;
     } else if (SetRestorePolicyResponse.CompletionCode != 0) {
-      DEBUG ((DEBUG_INFO, "[%a] - IpmiSetPowerRestorePolicy completion code: %r\n", __FUNCTION__, SetRestorePolicyResponse.CompletionCode));
+      DEBUG ((DEBUG_VERBOSE, "[%a] - IpmiSetPowerRestorePolicy completion code: %r\n", __FUNCTION__, SetRestorePolicyResponse.CompletionCode));
       return EFI_UNSUPPORTED;
     }
   }

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
@@ -1,7 +1,9 @@
-## @file
-#  IpmiPowerRestorePolicy.inf
+## @file IpmiPowerRestorePolicy.inf
 #
-#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  This is a driver for configure Power Restore Policy via IPMI command
+#
+#  Copyright (c) Microsoft Corporation.
+#  PDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
@@ -1,0 +1,33 @@
+## @file
+#  IpmiPowerRestorePolicy.inf
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IpmiPowerRestorePolicy
+  FILE_GUID                      = F417AA89-F059-4B3A-9533-2D7909B28347
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = IpmiPowerRestorePolicyEntry
+
+[Sources]
+  IpmiPowerRestorePolicy.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  PeimEntryPoint
+  DebugLib
+  BaseLib
+  IpmiCommandLib
+  PlatformPowerRestorePolicyConfigurationLib
+
+[Depex]
+  gPeiIpmiTransportPpiGuid
+

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
@@ -3,7 +3,7 @@
 #  This is a driver for configure Power Restore Policy via IPMI command
 #
 #  Copyright (c) Microsoft Corporation.
-#  PDX-License-Identifier: BSD-2-Clause-Patent
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
@@ -15,7 +15,7 @@ according to Platform setting via IPMI Chassis command.
 
 To leverage this feature,
 
-1. Add the following to your platform DSC's PEI section:
+1. Add the following to your platform DSC:
 
     ```ini
 
@@ -23,7 +23,7 @@ To leverage this feature,
 
     ```
 
-2. Add the following to your platform FDF's PEI section:
+2. Add the following to your platform FDF:
 
     ```ini
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
@@ -2,7 +2,8 @@
 
 ## Introduction
 
-The IpmiPowerRestorePolicy configure the Power Restore Policy by IPMI Chassis Command, For command detail, please refer to [IPMI Specification 2nd Generation v2.0](https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/ipmi-second-gen-interface-spec-v2-rev1-1.pdf)
+The IpmiPowerRestorePolicy configure the Power Restore Policy by IPMI Chassis Command, For command detail, please refer
+to [IPMI Specification 2nd Generation v2.0](https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/ipmi-second-gen-interface-spec-v2-rev1-1.pdf)
 
 ## High Level Module Interaction Flow
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-The IpmiPowerRestorePolicy configure the Power Restore Policy by IPMI Chassis Command, For command detail, please refer
-to [IPMI Specification 2nd Generation v2.0](https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/ipmi-second-gen-interface-spec-v2-rev1-1.pdf)
+The IpmiPowerRestorePolicy configures the Power Restore Policy by the IPMI Chassis Command. For command details, please
+refer to [IPMI Specification 2nd Generation v2.0](https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/ipmi-second-gen-interface-spec-v2-rev1-1.pdf)
 
 ## High Level Module Interaction Flow
 
@@ -19,6 +19,7 @@ To leverage this feature,
 
     ```ini
 
+    [Components.PEIM]
     IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
 
     ```

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/ReadMe.md
@@ -1,0 +1,39 @@
+# IpmiPowerRestorePolicy
+
+## Introduction
+
+The IpmiPowerRestorePolicy configure the Power Restore Policy by IPMI Chassis Command, For command detail, please refer to [IPMI Specification 2nd Generation v2.0](https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/ipmi-second-gen-interface-spec-v2-rev1-1.pdf)
+
+## High Level Module Interaction Flow
+
+The IpmiPowerRestorePolicy Dxe driver get current power restore policy and platform power restore policy setting first, if
+the setting is the same then just return EFI_SUCCESS, if it is mismatch, then it will configure the power restore policy
+according to Platform setting via IPMI Chassis command.
+
+## Feature Enablement
+
+To leverage this feature,
+
+1. Add the following to your platform DSC's PEI section:
+
+    ```ini
+
+    IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+
+    ```
+
+2. Add the following to your platform FDF's PEI section:
+
+    ```ini
+
+    INF  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+
+    ```
+
+## Platform Specific Library APIs
+
+- Implement `PlatformPowerRestorePolicyConfigurationLib` library as per interfaces defined in [PlatformPowerRestorePolicyConfigurationLib.h](../Include/Library/PlatformPowerRestorePolicyConfigurationLib.h)
+
+## Copyright
+
+Copyright (c) Microsoft Corporation.

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/MockApi.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/MockApi.c
@@ -1,0 +1,66 @@
+/** @file    MockApi.c
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+
+**/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <cmocka.h>
+
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/IpmiCommandLib.h>
+#include <Library/PlatformPowerRestorePolicyConfigurationLib.h>
+
+/**
+  @brief Mock this api locally in the test Get the Platform Power Restore Policy Setting Value object
+
+  @param PowerRestorePolicy
+  @retval EFI_STATUS
+**/
+EFI_STATUS
+EFIAPI
+GetPowerRestorePolicy (
+  OUT UINT8  *PowerRestorePolicy
+  )
+{
+  *PowerRestorePolicy = mock_type (UINT8);
+  return mock_type (UINTN);
+}
+
+EFI_STATUS
+EFIAPI
+IpmiGetChassisStatus (
+  OUT IPMI_GET_CHASSIS_STATUS_RESPONSE  *GetChassisStatusResponse
+  )
+{
+  GetChassisStatusResponse->CurrentPowerState = mock_type (UINT8);
+
+  return mock_type (UINTN);
+}
+
+EFI_STATUS
+EFIAPI
+IpmiSetPowerRestorePolicy (
+  IN  IPMI_SET_POWER_RESTORE_POLICY_REQUEST   *ChassisControlRequest,
+  OUT IPMI_SET_POWER_RESTORE_POLICY_RESPONSE  *ChassisControlResponse
+  )
+{
+  function_called ();
+
+  check_expected (ChassisControlRequest->PowerRestorePolicy.Uint8);
+
+  ChassisControlResponse->CompletionCode            = mock_type (UINT8);
+  ChassisControlResponse->PowerRestorePolicySupport =  ChassisControlRequest->PowerRestorePolicy.Bits.PowerRestorePolicy;
+
+  return mock_type (UINTN);
+}

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/MockApi.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/MockApi.c
@@ -1,6 +1,7 @@
-/** @file    MockApi.c
+/** @file MockApi.c
 
-  Copyright (c) Microsoft Corporation. All rights reserved.
+  Copyright (c) Microsoft Corporation.
+  PDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/MockApi.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/MockApi.c
@@ -1,7 +1,7 @@
 /** @file MockApi.c
 
   Copyright (c) Microsoft Corporation.
-  PDX-License-Identifier: BSD-2-Clause-Patent
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
@@ -25,7 +25,7 @@
 /**
   @brief Mock this api locally in the test Get the Platform Power Restore Policy Setting Value object
 
-  @param PowerRestorePolicy
+  @param[out] PowerRestorePolicy
   @retval EFI_STATUS
 **/
 EFI_STATUS

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.c
@@ -1,0 +1,379 @@
+/** @file    TestIpmiPowerRestorePolicyHost.c
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+
+**/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/UnitTestLib.h>
+
+//
+// Common header files
+//
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/IpmiCommandLib.h>
+#include <Library/PlatformPowerRestorePolicyConfigurationLib.h>
+
+#define UNIT_TEST_NAME     "TestIpmiPowerRestorePolicyHost"
+#define UNIT_TEST_VERSION  "1.0"
+
+//
+// Power Restore Policy configuration.
+//
+#define  POWER_RESTORE_POLICY_POWER_OFF   0x00
+#define  POWER_RESTORE_POLICY_LAST_STATE  0x01
+#define  POWER_RESTORE_POLICY_POWER_ON    0x02
+#define  POWER_RESTORE_POLICY_NO_CHANGE   0x03  // "Set Power Restore Policy"
+#define  POWER_RESTORE_POLICY_UNKNOWN     0x03  // "Get Chassis Status"
+
+///
+/// Global variables used in unit tests
+///
+
+extern
+EFI_STATUS
+EFIAPI
+IpmiPowerRestorePolicyEntry (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  );
+
+/**
+  Verifies that the BMC will not be updated if the local UEFI Config value is invalid
+
+  @param[in]  Context    not used
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+TestNoUpdateToBmcWhenLocalInvalid (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_PEI_FILE_HANDLE  FileHandle;
+  EFI_PEI_SERVICES     *PeiServices;
+
+  ZeroMem (
+    &FileHandle,
+    sizeof (FileHandle)
+    );
+
+  // IpmiGetChassisStatus returns current power state, restore power policy is bits [6:5] in current power state
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_POWER_ON << 5);
+  will_return (IpmiGetChassisStatus, EFI_DEVICE_ERROR);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_POWER_ON);
+  will_return (GetPowerRestorePolicy, EFI_DEVICE_ERROR); // fail to retrieve local value will prevent update
+
+  // Would be nice to explicitly check that a function isn't called,  test framework does not allow a value of zero
+  // However, not specifying an expected value will fail if it is called.
+  // expect_function_calls (IpmiSetPowerRestorePolicy, 0);
+
+  EFI_STATUS  status = IpmiPowerRestorePolicyEntry (
+                         FileHandle,
+                         (CONST EFI_PEI_SERVICES **)&PeiServices
+                         );
+
+  UT_ASSERT_EQUAL (status, EFI_DEVICE_ERROR);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verifies that the BMC will not be updated if the local UEFI Config value is the same as the BMC
+  Pick two different power policy values
+
+  @param[in]  Context    not used
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+TestNoUpdateToBmcWhenInSync (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_PEI_FILE_HANDLE  FileHandle;
+  EFI_PEI_SERVICES     *PeiServices;
+
+  ZeroMem (
+    &FileHandle,
+    sizeof (FileHandle)
+    );
+
+  // Would be nice to explicitly check that a function isn't called,  test framework does not allow a value of zero
+  // However, not specifying an expected value will fail if it is called.
+  // expect_function_calls (IpmiSetPowerRestorePolicy, 0);
+
+  // IpmiGetChassisStatus returns current power state, restore power policy is bits [6:5] in current power state
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_POWER_OFF << 5);
+  will_return (IpmiGetChassisStatus, EFI_SUCCESS);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_POWER_OFF);
+  will_return (GetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  EFI_STATUS  status = IpmiPowerRestorePolicyEntry (
+                         FileHandle,
+                         (CONST EFI_PEI_SERVICES **)&PeiServices
+                         );
+
+  UT_ASSERT_EQUAL (status, EFI_SUCCESS);
+
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_LAST_STATE << 5);
+  will_return (IpmiGetChassisStatus, EFI_SUCCESS);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_LAST_STATE);
+  will_return (GetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  status = IpmiPowerRestorePolicyEntry (
+             FileHandle,
+             (CONST EFI_PEI_SERVICES **)&PeiServices
+             );
+
+  UT_ASSERT_EQUAL (status, EFI_SUCCESS);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verifies that the BMC will not be updated if the local UEFI Config value is POWER_RESTORE_POLICY_NO_CHANGE
+
+  @param[in]  Context    not used
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+TestNoUpdateToBmcWhenLocalValueIsNoChange (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_PEI_FILE_HANDLE  FileHandle;
+  EFI_PEI_SERVICES     *PeiServices;
+
+  ZeroMem (
+    &FileHandle,
+    sizeof (FileHandle)
+    );
+
+  // Would be nice to explicitly check that a function isn't called,  test framework does not allow a value of zero
+  // However, not specifying an expected value will fail if it is called.
+  // expect_function_calls (IpmiSetPowerRestorePolicy, 0);
+
+  // IpmiGetChassisStatus returns current power state, restore power policy is bits [6:5] in current power state
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_POWER_OFF << 5);
+  will_return (IpmiGetChassisStatus, EFI_SUCCESS);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_NO_CHANGE);
+  will_return (GetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  EFI_STATUS  status = IpmiPowerRestorePolicyEntry (
+                         FileHandle,
+                         (CONST EFI_PEI_SERVICES **)&PeiServices
+                         );
+
+  UT_ASSERT_EQUAL (status, EFI_SUCCESS);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verifies that the BMC will not be updated if the local UEFI Config value is POWER_RESTORE_POLICY_NO_CHANGE
+
+  @param[in]  Context    not used
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+TestFailReturnedIfBmcUpdateFails (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_PEI_FILE_HANDLE  FileHandle;
+  EFI_PEI_SERVICES     *PeiServices;
+
+  ZeroMem (
+    &FileHandle,
+    sizeof (FileHandle)
+    );
+
+  // IpmiGetChassisStatus returns current power state, restore power policy is bits [6:5] in current power state
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_POWER_OFF << 5);
+  will_return (IpmiGetChassisStatus, EFI_SUCCESS);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_POWER_ON);
+  will_return (GetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  expect_function_calls (IpmiSetPowerRestorePolicy, 1);
+  expect_value (IpmiSetPowerRestorePolicy, ChassisControlRequest->PowerRestorePolicy.Uint8, POWER_RESTORE_POLICY_POWER_ON);
+
+  will_return (IpmiSetPowerRestorePolicy, 0);                     // completion code success
+  will_return (IpmiSetPowerRestorePolicy, EFI_INVALID_PARAMETER); //
+
+  EFI_STATUS  status = IpmiPowerRestorePolicyEntry (
+                         FileHandle,
+                         (CONST EFI_PEI_SERVICES **)&PeiServices
+                         );
+
+  UT_ASSERT_EQUAL (status, EFI_INVALID_PARAMETER);
+
+  // test that if IpmiSetPowerRestorePolicy returns success, but completion code is not, then will also fail
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_POWER_ON << 5);
+  will_return (IpmiGetChassisStatus, EFI_SUCCESS);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_POWER_OFF);
+  will_return (GetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  expect_function_calls (IpmiSetPowerRestorePolicy, 1);
+  expect_value (IpmiSetPowerRestorePolicy, ChassisControlRequest->PowerRestorePolicy.Uint8, POWER_RESTORE_POLICY_POWER_OFF);
+
+  will_return (IpmiSetPowerRestorePolicy, 2);           // completion code fail
+  will_return (IpmiSetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  status = IpmiPowerRestorePolicyEntry (
+             FileHandle,
+             (CONST EFI_PEI_SERVICES **)&PeiServices
+             );
+
+  UT_ASSERT_EQUAL (status, EFI_UNSUPPORTED);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Verifies that the BMC is updated and success is returned
+
+  @param[in]  Context    not used
+
+  @retval  UNIT_TEST_PASSED             The Unit test has completed and the test
+                                        case was successful.
+  @retval  UNIT_TEST_ERROR_TEST_FAILED  A test case assertion has failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+TestValidBmcUpdate (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_PEI_FILE_HANDLE  FileHandle;
+  EFI_PEI_SERVICES     *PeiServices;
+
+  ZeroMem (
+    &FileHandle,
+    sizeof (FileHandle)
+    );
+
+  // test that if IpmiSetPowerRestorePolicy returns success, but completion code is not, then will also fail
+  will_return (IpmiGetChassisStatus, POWER_RESTORE_POLICY_POWER_ON << 5);
+  will_return (IpmiGetChassisStatus, EFI_SUCCESS);
+
+  will_return (GetPowerRestorePolicy, POWER_RESTORE_POLICY_POWER_OFF);
+  will_return (GetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  expect_function_calls (IpmiSetPowerRestorePolicy, 1);
+  expect_value (IpmiSetPowerRestorePolicy, ChassisControlRequest->PowerRestorePolicy.Uint8, POWER_RESTORE_POLICY_POWER_OFF);
+
+  will_return (IpmiSetPowerRestorePolicy, 0);           // completion code success
+  will_return (IpmiSetPowerRestorePolicy, EFI_SUCCESS); // fail to retrieve local value will prevent update
+
+  EFI_STATUS  status = IpmiPowerRestorePolicyEntry (
+                         FileHandle,
+                         (CONST EFI_PEI_SERVICES **)&PeiServices
+                         );
+
+  UT_ASSERT_EQUAL (status, EFI_SUCCESS);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+Initialize the unit test framework, suites and run test
+
+ @retval  EFI_SUCCESS           All test cases were dispatched.
+ @retval  EFI_OUT_OF_RESOURCES  There are not enough resources available to
+                                initialize the unit tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      TestIpmiPowerRestorePolicyHostTests;
+
+  Framework = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    goto EXIT;
+  }
+
+  //
+  // Populate the TestIpmiPowerRestorePolicyHostTests Unit Test Suite.
+  //
+  Status = CreateUnitTestSuite (&TestIpmiPowerRestorePolicyHostTests, Framework, "TestIpmiPowerRestorePolicyHost Tests", "Simple.Math", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for TestIpmiPowerRestorePolicyHostTests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto EXIT;
+  }
+
+  AddTestCase (TestIpmiPowerRestorePolicyHostTests, "Don't Update BMC when local config is invalid", "NoBmcUpdateInvalid", TestNoUpdateToBmcWhenLocalInvalid, NULL, NULL, NULL);
+  AddTestCase (TestIpmiPowerRestorePolicyHostTests, "Don't Need to update BMC when already the same", "NoBmcUpdateInSync", TestNoUpdateToBmcWhenInSync, NULL, NULL, NULL);
+  AddTestCase (TestIpmiPowerRestorePolicyHostTests, "Don't Need to update BMC when local value is no update", "NoBmcUpdateNoChange", TestNoUpdateToBmcWhenLocalValueIsNoChange, NULL, NULL, NULL);
+  AddTestCase (TestIpmiPowerRestorePolicyHostTests, "Verify fail returned if BMC Update fails", "FailIfBmcUpdateFail", TestFailReturnedIfBmcUpdateFails, NULL, NULL, NULL);
+  AddTestCase (TestIpmiPowerRestorePolicyHostTests, "Verify successful Bmc Update", "ValidBmcUpdate", TestValidBmcUpdate, NULL, NULL, NULL);
+
+  //
+  // Execute the tests.
+  //
+  Status = RunAllTestSuites (Framework);
+
+EXIT:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  return UefiTestMain ();
+}

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.c
@@ -1,6 +1,7 @@
-/** @file    TestIpmiPowerRestorePolicyHost.c
+/** @file TestIpmiPowerRestorePolicyHost.c
 
-  Copyright (c) Microsoft Corporation. All rights reserved.
+  Copyright (c) Microsoft Corporation.
+  PDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.c
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.c
@@ -1,7 +1,7 @@
 /** @file TestIpmiPowerRestorePolicyHost.c
 
   Copyright (c) Microsoft Corporation.
-  PDX-License-Identifier: BSD-2-Clause-Patent
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
@@ -1,8 +1,7 @@
-## @file    TestIpmiPowerRestorePolicyHost.inf
+## @file TestIpmiPowerRestorePolicyHost.inf
 #
-#  Copyright (c) Microsoft Corporation. All rights reserved.
-#
-#  Description
+#  Copyright (c) Microsoft Corporation.
+#  PDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
@@ -1,0 +1,34 @@
+## @file    TestIpmiPowerRestorePolicyHost.inf
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#
+#  Description
+#
+##
+
+[Defines]
+INF_VERSION    = 0x00010005
+BASE_NAME      = TestIpmiPowerRestorePolicyHost
+FILE_GUID      = B86C64E0-D547-4BF1-8692-4C52CB3DB946
+MODULE_TYPE    = HOST_APPLICATION
+VERSION_STRING = 1.0
+
+[Sources]
+  TestIpmiPowerRestorePolicyHost.c
+  MockApi.c
+  ../IpmiPowerRestorePolicy.c
+
+
+[Packages]
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UnitTestLib
+
+[Pcd]

--- a/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
+++ b/IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
@@ -1,7 +1,7 @@
 ## @file TestIpmiPowerRestorePolicyHost.inf
 #
 #  Copyright (c) Microsoft Corporation.
-#  PDX-License-Identifier: BSD-2-Clause-Patent
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
@@ -1,5 +1,4 @@
-/** @file
-  PlatformPowerRestorePolicyConfigurationLibNull.h
+/** @file PlatformPowerRestorePolicyConfigurationLibNull.c
 
   Copyright (c) Microsoft Corporation.
   PDX-License-Identifier: BSD-2-Clause-Patent

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
@@ -1,0 +1,31 @@
+/** @file
+  PlatformPowerRestorePolicyConfigurationLibNull.h
+
+  Copyright (c) Microsoft Corporation.
+
+**/
+#include <Uefi.h>
+#include <Library/PlatformPowerRestorePolicyConfigurationLib.h>
+
+/**
+  Get PowerRestorePolicy
+
+  @param[out] PowerRestorePolicy  The PowerRestorePolicy setting of the platform
+
+  @retval EFI_INVALID_PARAMETER      The input parameter is invalid.
+  @retval EFI_SUCCESS                Get PowerRestorePolicy successfully.
+**/
+EFI_STATUS
+EFIAPI
+GetPowerRestorePolicy (
+  OUT UINT8  *PowerRestorePolicy
+  )
+{
+  if (PowerRestorePolicy == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *PowerRestorePolicy = POWER_RESTORE_POLICY_NO_CHANGE;
+
+  return EFI_SUCCESS;
+}

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
@@ -1,7 +1,7 @@
 /** @file PlatformPowerRestorePolicyConfigurationLibNull.c
 
   Copyright (c) Microsoft Corporation.
-  PDX-License-Identifier: BSD-2-Clause-Patent
+  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 #include <Uefi.h>

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.c
@@ -2,6 +2,7 @@
   PlatformPowerRestorePolicyConfigurationLibNull.h
 
   Copyright (c) Microsoft Corporation.
+  PDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 #include <Uefi.h>

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
@@ -1,7 +1,7 @@
 ## @file PlatformPowerRestorePolicyConfigurationLibNull.inf
 #
 #  Copyright (c) Microsoft Corporation.
-#  PDX-License-Identifier: BSD-2-Clause-Patent
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
@@ -1,0 +1,31 @@
+## @file PlatformPowerRestorePolicyConfigurationLibNull.inf
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PlatformPowerRestorePolicyConfigurationLibNull
+  FILE_GUID                      = 3D4E325A-0A2D-4BE7-8238-4FDC714CB903
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PlatformPowerRestorePolicyConfigurationLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  PlatformPowerRestorePolicyConfigurationLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+
+[Guids]
+
+[Depex]

--- a/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
+++ b/IpmiFeaturePkg/Library/PlatformPowerRestorePolicyConfigurationLibNull/PlatformPowerRestorePolicyConfigurationLibNull.inf
@@ -1,6 +1,7 @@
 ## @file PlatformPowerRestorePolicyConfigurationLibNull.inf
 #
-#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Copyright (c) Microsoft Corporation.
+#  PDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 

--- a/IpmiFeaturePkg/Test/IpmiFeaturePkgHostTest.dsc
+++ b/IpmiFeaturePkg/Test/IpmiFeaturePkgHostTest.dsc
@@ -44,6 +44,7 @@
   IpmiFeaturePkg/GenericIpmi/Test/GenericIpmiUnitTest.inf
   IpmiFeaturePkg/Test/UnitTest/WatchdogUnitTest/WatchdogUnitTest.inf
   IpmiFeaturePkg/Test/UnitTest/BootOptionUnitTest/BootOptionUnitTest.inf
+  IpmiFeaturePkg/IpmiPowerRestorePolicy/UnitTest/TestIpmiPowerRestorePolicyHost.inf
   IpmiFeaturePkg/SpmiTable/GoogleTest/SpmiTableGoogleTest.inf {
     <PcdsFixedAtBuild>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x06  # Disable Debug ASSERT for googletest


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Implement IpmiPowerRestorePolicy module for configuring Power Restore Policy via IPMI Chassis Command

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Implement IpmiPowerRestorePolicy module for configuring Power Restore Policy via IPMI Chassis Command, it provides a PlatformPowerRestorePolicyConfigurationLib to retrieve platform setting.
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Unit tests
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: add feature readme file

## How This Was Tested

1. Verified the build by pipeline.
2. Verified the Power Restore Policy can be configured correctly on real HW.

## Integration Instructions

To leverage this feature,

1. Add the following to your platform DSC's PEI section:

    ```ini

    IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf

    ```

2. Add the following to your platform FDF's PEI section:

    ```ini

    INF  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf

