### PR TITLE
Correct the API name in IpmiBaseLibDxe.c and link IpmiBaseLibDxe for UEFI_APPLICATION module type

### DIFF
--- a/IpmiFeaturePkg/IpmiCoreLibs.dsc.inc
+++ b/IpmiFeaturePkg/IpmiCoreLibs.dsc.inc
@@ -17,7 +17,7 @@
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.inf
 
-[LibraryClasses.common.DXE_DRIVER,LibraryClasses.common.UEFI_DRIVER,LibraryClasses.common.DXE_RUNTIME_DRIVER]
+[LibraryClasses.common.DXE_DRIVER,LibraryClasses.common.UEFI_DRIVER,LibraryClasses.common.DXE_RUNTIME_DRIVER,LibraryClasses.common.UEFI_APPLICATION]
   IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.inf
 
 [LibraryClasses.common.DXE_SMM_DRIVER,LibraryClasses.common.SMM_CORE]

--- a/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
@@ -70,7 +70,7 @@ IpmiSubmitCommand (
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
 EFI_STATUS
-IpmiGetBmcStatus (
+GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress
   )


### PR DESCRIPTION
## Description

Correct the API name in IpmiBaseLibDxe.c and link IpmiBaseLibDxe for UEFI_APPLICATION module type.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified the API could be called in DXE.

## Integration Instructions

N/A
