### PR TITLE
Change IpmiBaseLibNull to BASE library type

### DIFF
--- a/IpmiFeaturePkg/Include/Library/IpmiBaseLib.h
+++ b/IpmiFeaturePkg/Include/Library/IpmiBaseLib.h
@@ -29,8 +29,8 @@
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
   IN UINT8       Command,
@@ -49,8 +49,8 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress

--- a/IpmiFeaturePkg/Include/Library/IpmiBaseLib.h
+++ b/IpmiFeaturePkg/Include/Library/IpmiBaseLib.h
@@ -29,6 +29,7 @@
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
@@ -48,6 +49,7 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,

--- a/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
@@ -27,6 +27,7 @@ STATIC IPMI_TRANSPORT  *mIpmiTransport = NULL;
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
@@ -69,6 +70,7 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,

--- a/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
@@ -27,8 +27,8 @@ STATIC IPMI_TRANSPORT  *mIpmiTransport = NULL;
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
   IN UINT8       Command,
@@ -70,8 +70,8 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress

--- a/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.c
@@ -6,12 +6,10 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
+#include <Uefi.h>
 #include <Library/BaseLib.h>
-#include <Library/UefiBootServicesTableLib.h>
-#include <Library/DxeServicesLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IpmiBaseLib.h>
-#include <Ppi/IpmiTransportPpi.h>
 
 /**
   Sends a IPMI command to the BMC and returns the response.

--- a/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.c
@@ -25,6 +25,7 @@
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
@@ -47,6 +48,7 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,

--- a/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.c
@@ -25,8 +25,8 @@
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
   IN UINT8       Command,
@@ -48,8 +48,8 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress

--- a/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.inf
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.inf
@@ -2,6 +2,7 @@
 #
 # @copyright
 # Copyright 2011 - 2021 Intel Corporation. <BR>
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -9,9 +10,9 @@
   INF_VERSION                   = 0x00010005
   BASE_NAME                     = IpmiBaseLibNull
   FILE_GUID                     = 3444CF4F-8B88-4579-9A95-2E7678C0E945
-  MODULE_TYPE                   = DXE_SMM_DRIVER
+  MODULE_TYPE                   = BASE
   VERSION_STRING                = 1.0
-  LIBRARY_CLASS                 = IpmiBaseLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER SMM_CORE
+  LIBRARY_CLASS                 = IpmiBaseLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -28,8 +29,6 @@
 
 [LibraryClasses]
   BaseLib
-  UefiBootServicesTableLib
-  DxeServicesLib
   DebugLib
 
 [Guids]

--- a/IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.c
@@ -26,6 +26,7 @@
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
@@ -67,6 +68,7 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,

--- a/IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.c
@@ -26,8 +26,8 @@
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
   IN UINT8       Command,
@@ -68,8 +68,8 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress

--- a/IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.c
@@ -29,8 +29,8 @@ STATIC IPMI_TRANSPORT  *mIpmiTransport = NULL;
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
   IN UINT8       Command,
@@ -72,8 +72,8 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress

--- a/IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.c
@@ -29,6 +29,7 @@ STATIC IPMI_TRANSPORT  *mIpmiTransport = NULL;
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
@@ -71,6 +72,7 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,

--- a/IpmiFeaturePkg/Library/MockIpmi/IpmiBaseLibMock.c
+++ b/IpmiFeaturePkg/Library/MockIpmi/IpmiBaseLibMock.c
@@ -28,6 +28,7 @@ STATIC UINT8  ResponseBuffer[MOCK_BASE_IPMI_BUFFER_SIZE];
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
@@ -81,6 +82,7 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
+EFIAPI
 EFI_STATUS
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,

--- a/IpmiFeaturePkg/Library/MockIpmi/IpmiBaseLibMock.c
+++ b/IpmiFeaturePkg/Library/MockIpmi/IpmiBaseLibMock.c
@@ -28,8 +28,8 @@ STATIC UINT8  ResponseBuffer[MOCK_BASE_IPMI_BUFFER_SIZE];
   @retval   EFI_SUCCESS             Successfully send IPMI command.
   @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 IpmiSubmitCommand (
   IN UINT8       NetFunction,
   IN UINT8       Command,
@@ -82,8 +82,8 @@ IpmiSubmitCommand (
   @retval   EFI_SUCCESS             Successfully retrieved BMC status
   @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
 **/
-EFIAPI
 EFI_STATUS
+EFIAPI
 GetBmcStatus (
   OUT BMC_STATUS      *BmcStatus,
   OUT SM_COM_ADDRESS  *ComAddress


### PR DESCRIPTION
## Description

The IpmiBaseLibNull implementation currently restricts its library types and consumes libraries that it does not use. This change cleans up and generalizes the NULL imlementation. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local build

## Integration Instructions

N/A
