### PR TITLE
Align with DxeGenericIpmi to use PcdIpmiCommandTimeoutSeconds

### DIFF
--- a/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
@@ -32,9 +32,6 @@
 // Static definitions for the IPMI PEIM
 //
 
-#define BMC_IPMI_TIMEOUT_PEI  5         // [s] Single IPMI request timeout
-#define IPMI_DELAY_UNIT_PEI   1000      // [s] Each KSC IO delay
-
 /**
   The entry point of the Ipmi PEIM. Installs Ipmi PPI interface.
 
@@ -74,7 +71,7 @@ PeimIpmiInterfaceInit (
   // ticks in that period by 100 to get the number of ticks in a 1 second timeout
   //
   DEBUG ((DEBUG_INFO, "[IPMI] IPMI STACK Initialization\n"));
-  mIpmiInstance->IpmiTimeoutPeriod = (BMC_IPMI_TIMEOUT_PEI *1000*1000) / IPMI_DELAY_UNIT_PEI;
+  mIpmiInstance->IpmiTimeoutPeriod = (PcdGet8 (PcdIpmiCommandTimeoutSeconds) *1000*1000) / IPMI_DELAY_UNIT;
   DEBUG ((DEBUG_INFO, "[IPMI] IpmiTimeoutPeriod = 0x%x\n", mIpmiInstance->IpmiTimeoutPeriod));
 
   //

--- a/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
+++ b/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
@@ -55,6 +55,7 @@
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiBmcReadyDelayTimer
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCommandMaxReties
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCheckSelfTestResults
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCommandTimeoutSeconds
   gIpmiFeaturePkgTokenSpaceGuid.PcdBmcTimeoutSeconds
 
 [Depex]

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -88,16 +88,6 @@
   ReportStatusCodeLib|MdeModulePkg/Library/SmmReportStatusCodeLib/SmmReportStatusCodeLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
 
-[LibraryClasses.X64]
-  RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
-!if $(TOOL_CHAIN_TAG) == VS2019 or $(TOOL_CHAIN_TAG) == VS2022
-  # Provide StackCookie support lib so that we can link to /GS exports for VS builds
-  NULL|MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
-  BaseBinSecurityLib|MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
-!else
-  BaseBinSecurityLib|MdePkg/Library/BaseBinSecurityLibNull/BaseBinSecurityLibNull.inf
-!endif
-
 [Components]
   IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLib.inf
   IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.inf


### PR DESCRIPTION
## Description

Align with DxeGenericIpmi to use PcdIpmiCommandTimeoutSeconds to control IPMI cmd timeout.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified build and the IPMI cmd timeout can be controlled by PcdIpmiCommandTimeoutSeconds in all phase.

## Integration Instructions

The default PcdIpmiCommandTimeoutSeconds is still 5 second, Platform is flexible to configure it in DSC file to meet platform requirement.
