### PR TITLE
fix multi-part read for ssif

### DIFF
--- a/IpmiFeaturePkg/Library/IpmiTransportLibSsif/Ssif.c
+++ b/IpmiFeaturePkg/Library/IpmiTransportLibSsif/Ssif.c
@@ -186,13 +186,13 @@ ReceiveBmcDataFromPort (
       if (BlockBuffer[0] == 0xFF) {
         Done = TRUE;
       } else {
-        if (BlockBuffer[0] != BlockNumber + 1) {
-          DEBUG ((DEBUG_ERROR, "[SSIF] SMBus block out of order! Expected %d, Received %d.\n", BlockNumber + 1, BlockBuffer[0]));
+        if (BlockBuffer[0] != BlockNumber) {
+          DEBUG ((DEBUG_ERROR, "[SSIF] SMBus block out of order! Expected %d, Received %d.\n", BlockNumber, BlockBuffer[0]));
           Status = EFI_DEVICE_ERROR;
           goto Exit;
         }
 
-        BlockNumber = BlockBuffer[0];
+        BlockNumber = BlockBuffer[0] + 1;
       }
     }
 

--- a/IpmiFeaturePkg/Test/UnitTest/SsifUnitTest/BmcSmbusLibTest.c
+++ b/IpmiFeaturePkg/Test/UnitTest/SsifUnitTest/BmcSmbusLibTest.c
@@ -150,7 +150,7 @@ BmcSmbusBlockRead (
       ReadBlock[1] = 1;
       CopyMem (&ReadBlock[2], &RxBuffer[RxOffset], SSIF_MAX_READ_SIZE - 2);
       RxOffset    += SSIF_MAX_READ_SIZE - 2;
-      RxBlock      = 1;
+      RxBlock      = 0;
       *BlockLength = SSIF_MAX_READ_SIZE;
     } else {
       CopyMem (&ReadBlock[0], &RxBuffer[RxOffset], RxSize);


### PR DESCRIPTION
## Description

this is to fix multi-part read issue explained in this bug https://github.com/microsoft/mu_feature_ipmi/issues/188

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

The change was tested with latest BMC that is spec compliant. 

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>