### PR TITLE
Remove the ACPI device scope link.

### DIFF
--- a/IpmiFeaturePkg/BmcAcpi/BmcSsdt/BmcSsdt.asl
+++ b/IpmiFeaturePkg/BmcAcpi/BmcSsdt/BmcSsdt.asl
@@ -18,11 +18,6 @@ DefinitionBlock (
     )
 {
 
-  External(\_SB.PC00.LPC0, DeviceObj)
-
-  Scope (\_SB.PC00.LPC0)
-  {
-    #include "IpmiOprRegions.asi"
-  }
+  #include "IpmiOprRegions.asi"
 
 }


### PR DESCRIPTION
## Description

Remove the ACPI device scope link.

Root cause:

If the system LPC device is not "PC00.LPC0", this SSDT is invaild.

It does not need to be put under any device scope, it just need an ASL device in the root path with all the required methods then the IPMI device will be initialized success and show up in device manager.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

![IPMC2](https://github.com/microsoft/mu_feature_ipmi/assets/21114822/a61b86c9-74ba-4e54-86f5-b94a2ef3ecca)


## Integration Instructions

N/A