### PR TITLE
Publish BMC Status even on failure from PEI

### DIFF
--- a/IpmiFeaturePkg/GenericIpmi/Common/GenericIpmi.h
+++ b/IpmiFeaturePkg/GenericIpmi/Common/GenericIpmi.h
@@ -85,14 +85,6 @@ typedef struct {
   UINT8    ResponseData[MAX_TEMP_DATA - IPMI_RESPONSE_HEADER_SIZE];
 } IPMI_RESPONSE;
 
-//
-// Structure to communicate BMC state from PEI to DXE.
-//
-
-typedef struct _IPMI_BMC_HOB {
-  BMC_STATUS    BmcStatus;
-} IPMI_BMC_HOB;
-
 #pragma pack()
 
 /**

--- a/IpmiFeaturePkg/GenericIpmi/Common/IpmiInitialize.c
+++ b/IpmiFeaturePkg/GenericIpmi/Common/IpmiInitialize.c
@@ -372,7 +372,6 @@ IpmiInitializeBmc (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to get device ID. %r\n", __FUNCTION__, Status));
-    return Status;
   }
 
   //
@@ -393,7 +392,6 @@ IpmiInitializeBmc (
 
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to get self test results. %r\n", __FUNCTION__, Status));
-      return Status;
     }
   }
 

--- a/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.c
@@ -106,7 +106,6 @@ PeimIpmiInterfaceInit (
   Status = IpmiInitializeBmc (mIpmiInstance);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "[IPMI] Failed to initialize BMC state. %r\n", Status));
-    return Status;
   }
 
   //

--- a/IpmiFeaturePkg/Include/IpmiInterface.h
+++ b/IpmiFeaturePkg/Include/IpmiInterface.h
@@ -26,6 +26,18 @@ typedef UINT32 BMC_STATUS;
 #define BMC_NOTREADY            4
 
 //
+// Structure to communicate BMC state from PEI to DXE.
+//
+
+#pragma pack(1)
+
+typedef struct _IPMI_BMC_HOB {
+  BMC_STATUS    BmcStatus;
+} IPMI_BMC_HOB;
+
+#pragma pack()
+
+//
 //  IPMI Function Prototypes
 //
 typedef


### PR DESCRIPTION
## Description

Removes the quick returns that cause the BMC Status HOB to not be created during failures in PEI. This allows DXE and MM to check the original init attempt status and fail out quickly if needed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
