### PR TITLE
IpmiFeaturePkg/IpmiSmbios/GoogleTest/IpmiSmbiosGoogleTest: Fix unit t…

### DIFF
--- a/IpmiFeaturePkg/IpmiSmbios/GoogleTest/IpmiSmbiosGoogleTest.inf
+++ b/IpmiFeaturePkg/IpmiSmbios/GoogleTest/IpmiSmbiosGoogleTest.inf
@@ -34,7 +34,6 @@
   MemoryAllocationLib
   BaseMemoryLib
   DebugLib
-  IpmiCommandLib
   GoogleTestLib
 
 [Protocols]

--- a/IpmiFeaturePkg/Test/IpmiFeaturePkgHostTest.dsc
+++ b/IpmiFeaturePkg/Test/IpmiFeaturePkgHostTest.dsc
@@ -50,7 +50,10 @@
       gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x06  # Disable Debug ASSERT for googletest
   }
 
-  IpmiFeaturePkg/IpmiSmbios/GoogleTest/IpmiSmbiosGoogleTest.inf
+  IpmiFeaturePkg/IpmiSmbios/GoogleTest/IpmiSmbiosGoogleTest.inf {
+    <LibraryClasses>
+      UefiBootServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
+  }
 
   #
   # Build HOST_APPLICATION Libraries


### PR DESCRIPTION
## Description

Unit tests started failing due to compilation errors. This stemmed from a bug fixed in microsoft/mu_basecore#891. Once this bug was fixed, the unit tests starting to be compiled which blocked pipelines.


For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Local CI.

## Integration Instructions
N/A