### PR TITLE
Initialize the FRB2 watchdog timer in DXE phase if PEI is not supported.

### DIFF
--- a/IpmiFeaturePkg/IpmiWatchdog/Dxe/WatchdogDxe.c
+++ b/IpmiFeaturePkg/IpmiWatchdog/Dxe/WatchdogDxe.c
@@ -130,7 +130,7 @@ IpmiWatchdogDxeEntryPoint (
   //
   // For BIOS not having PEI phase, enable IPMI FRB2 watchdog timer here.
   //
-  if (mWatchdogPolicy.Frb2Enabled && WatchdogTimer.TimerUse.Bits.TimerRunning == 0) {
+  if ((mWatchdogPolicy.Frb2Enabled) && (WatchdogTimer.TimerUse.Bits.TimerRunning == 0)) {
     IpmiEnableWatchdogTimer (
       IPMI_WATCHDOG_TIMER_BIOS_FRB2,
       mWatchdogPolicy.Frb2TimeoutAction,

--- a/IpmiFeaturePkg/IpmiWatchdog/Dxe/WatchdogDxe.c
+++ b/IpmiFeaturePkg/IpmiWatchdog/Dxe/WatchdogDxe.c
@@ -117,12 +117,12 @@ IpmiWatchdogDxeEntryPoint (
   //
   Status = IpmiGetWatchdogTimer (&WatchdogTimer);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "%a: Failed to get Watchdog Timer.\n", __FUNCTION__));
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get Watchdog Timer.\n", __FUNCTION__));
     return Status;
   }
 
   DEBUG ((
-    DEBUG_INFO,
+    DEBUG_VERBOSE,
     "IPMI Watchdog timer status: %a\n",
     WatchdogTimer.TimerUse.Bits.TimerRunning ? "Running" : "Stopped"
     ));


### PR DESCRIPTION
Initialize the FRB2 watchdog timer in DXE phase if PEI is not supported.

## Description

PEIM driver support was limited on ARM based project and caused FRB2
watchdog timer was not enabled.

Expected Behavior:
FRB2 watchdog timer should be set correctly based on policy. 

FIX APPLIED:
Add FRB2 timer running check, if timer is not running and policy is set,
enable FRB2 watchdog timer.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with ARM based project and observed the watchdog timer was set
based on policy setting.

## Integration Instructions

N/A

