### PR TITLE
Implement StandaloneMmGenericIpmi driver and IpmiBaseLibMm library

### DIFF
--- a/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.c
@@ -58,7 +58,7 @@ InitializeStandaloneMmGenericIpmi (
   mIpmiInstance = AllocateZeroPool (sizeof (IPMI_BMC_INSTANCE_DATA));
   ASSERT (mIpmiInstance != NULL);
   if (mIpmiInstance == NULL) {
-    DEBUG ((EFI_D_ERROR, "ERROR!! Null Pointer returned by AllocateZeroPool ()\n"));
+    DEBUG ((DEBUG_ERROR, "ERROR!! Null Pointer returned by AllocateZeroPool ()\n"));
     ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -111,5 +111,5 @@ InitializeStandaloneMmGenericIpmi (
                     );
   ASSERT_EFI_ERROR (Status);
 
-  return EFI_SUCCESS;
+  return Status;
 }

--- a/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.c
@@ -1,0 +1,115 @@
+/** @file
+  Generic Standalone MM IPMI stack driver
+
+  @copyright
+  Copyright 1999 - 2021 Intel Corporation. <BR>
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+//
+// Statements that include other files
+//
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/IpmiBaseLib.h>
+#include <Library/TimerLib.h>
+#include <Library/HobLib.h>
+
+#include <IndustryStandard/Ipmi.h>
+#include <SmStatusCodes.h>
+
+#include <GenericIpmi.h>
+
+IPMI_BMC_INSTANCE_DATA  *mIpmiInstance;
+EFI_HANDLE              mImageHandle;
+
+/**
+  Setup and initialize the BMC for the Standalone MM phase.  In order to verify the BMC is functioning
+  as expected, the BMC Selftest is performed.  The results are then checked and any errors are
+  reported to the error manager.  Errors are collected throughout this routine and reported
+  just prior to installing the driver.  If there are more errors than MAX_SOFT_COUNT, then they
+  will be ignored.
+
+  @param[in]  ImageHandle   A handle to driver image.
+  @param[in]  SystemTable   A pointer to system table.
+
+  @retval     EFI_SUCCESS   Successful driver initialization.
+**/
+EFI_STATUS
+EFIAPI
+InitializeStandaloneMmGenericIpmi (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS         Status;
+  EFI_HANDLE         Handle;
+  IPMI_BMC_HOB       *BmcHob;
+  EFI_HOB_GUID_TYPE  *GuidHob;
+
+  DEBUG ((DEBUG_INFO, "InitializeStandaloneMmGenericIpmi entry\n"));
+  mImageHandle = ImageHandle;
+
+  mIpmiInstance = AllocateZeroPool (sizeof (IPMI_BMC_INSTANCE_DATA));
+  ASSERT (mIpmiInstance != NULL);
+  if (mIpmiInstance == NULL) {
+    DEBUG ((EFI_D_ERROR, "ERROR!! Null Pointer returned by AllocateZeroPool ()\n"));
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Initialize the KCS transaction timeout. Assume delay unit is 1000 us.
+  //
+  mIpmiInstance->IpmiTimeoutPeriod =
+    (PcdGet8 (PcdIpmiCommandTimeoutSeconds) * 1000 * 1000) / IPMI_DELAY_UNIT;
+
+  //
+  // Initialize IPMI IO Base, we still use SMS IO base to get device ID and
+  // Self-test result since MM IF may have different cmds supported.
+  //
+
+  mIpmiInstance->Signature                       = SM_IPMI_BMC_SIGNATURE;
+  mIpmiInstance->SlaveAddress                    = BMC_SLAVE_ADDRESS;
+  mIpmiInstance->BmcStatus                       = BMC_NOTREADY;
+  mIpmiInstance->IpmiTransport.IpmiSubmitCommand = IpmiSendCommand;
+  mIpmiInstance->IpmiTransport.GetBmcStatus      = IpmiGetBmcStatus;
+
+  //
+  // Check if PEI already initialized the BMC connection.
+  //
+
+  GuidHob = GetFirstGuidHob (&gIpmiBmcHobGuid);
+  if (GuidHob == NULL) {
+    //
+    // PEI did not create a BMC HOB, initialize the BMC now.
+    //
+
+    Status = IpmiInitializeBmc (mIpmiInstance);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "[IPMI] Failed to initialize BMC. %r\n", Status));
+      return Status;
+    }
+  } else {
+    BmcHob                   = (IPMI_BMC_HOB *)GET_GUID_HOB_DATA (GuidHob);
+    mIpmiInstance->BmcStatus = BmcHob->BmcStatus;
+    DEBUG ((DEBUG_INFO, "[IPMI] Found IPMI BMC HOB. BMC Status = 0x%d\n", BmcHob->BmcStatus));
+  }
+
+  Handle = NULL;
+  DEBUG ((DEBUG_INFO, "[IPMI] Installing MM protocol!\n"));
+  Status = gMmst->MmInstallProtocolInterface (
+                    &Handle,
+                    &gSmmIpmiTransportProtocolGuid,
+                    EFI_NATIVE_INTERFACE,
+                    &mIpmiInstance->IpmiTransport
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  return EFI_SUCCESS;
+}

--- a/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.c
+++ b/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.c
@@ -13,11 +13,9 @@
 #include <Uefi.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/BaseMemoryLib.h>
 #include <Library/MmServicesTableLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/IpmiBaseLib.h>
-#include <Library/TimerLib.h>
 #include <Library/HobLib.h>
 
 #include <IndustryStandard/Ipmi.h>

--- a/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
+++ b/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
@@ -1,0 +1,59 @@
+## @file
+# Generic IPMI StandaloneMm Driver.
+#
+# @copyright
+# Copyright 2010 - 2021 Intel Corporation. <BR>
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                         = 0x00010017
+  BASE_NAME                           = StandaloneMmGenericIpmi
+  FILE_GUID                           = CE919FB2-87DE-4583-A878-CEEAF6098A35
+  MODULE_TYPE                         = MM_STANDALONE
+  PI_SPECIFICATION_VERSION            = 0x00010032
+  VERSION_STRING                      = 1.0
+  ENTRY_POINT                         = InitializeStandaloneMmGenericIpmi
+
+[Sources]
+  ../Common/IpmiHooks.h
+  ../Common/IpmiHooks.c
+  ../Common/GenericIpmi.c
+  ../Common/IpmiInitialize.c
+  ../Common/GenericIpmi.h
+  StandaloneMmGenericIpmi.c          #GenericIpmi.c+IpmiBmcInitialize.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  MemoryAllocationLib
+  BaseLib
+  MmServicesTableLib
+  DebugLib
+  StandaloneMmDriverEntryPoint
+  IoLib
+  ReportStatusCodeLib
+  TimerLib
+  HobLib
+  IpmiTransportLib
+  IpmiPlatformLib
+
+[Protocols]
+  gSmmIpmiTransportProtocolGuid                     # PROTOCOL ALWAYS_PRODUCED
+
+[Guids]
+  gIpmiBmcHobGuid
+
+[Pcd]
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiBmcReadyDelayTimer
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCommandTimeoutSeconds
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCommandMaxReties
+  gIpmiFeaturePkgTokenSpaceGuid.PcdBmcTimeoutSeconds
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCheckSelfTestResults
+
+[Depex]
+  TRUE

--- a/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
+++ b/IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
@@ -34,7 +34,6 @@
   MmServicesTableLib
   DebugLib
   StandaloneMmDriverEntryPoint
-  IoLib
   ReportStatusCodeLib
   TimerLib
   HobLib

--- a/IpmiFeaturePkg/IpmiCoreLibs.dsc.inc
+++ b/IpmiFeaturePkg/IpmiCoreLibs.dsc.inc
@@ -22,3 +22,6 @@
 
 [LibraryClasses.common.DXE_SMM_DRIVER,LibraryClasses.common.SMM_CORE]
   IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf
+
+[LibraryClasses.common.MM_STANDALONE,LibraryClasses.common.MM_CORE_STANDALONE]
+  IpmiBaseLib|IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf

--- a/IpmiFeaturePkg/IpmiFeaturePkg.ci.yaml
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.ci.yaml
@@ -39,7 +39,8 @@
             "MdePkg/MdePkg.dec",
             "MdeModulePkg/MdeModulePkg.dec",
             "PolicyServicePkg/PolicyServicePkg.dec",
-            "IpmiFeaturePkg/IpmiFeaturePkg.dec"
+            "IpmiFeaturePkg/IpmiFeaturePkg.dec",
+            "StandaloneMmPkg/StandaloneMmPkg.dec"
         ],
         # For host based unit tests
         "AcceptableDependencies-HOST_APPLICATION":[

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -58,6 +58,9 @@
   IpmiPlatformLib|IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
   PlatformCmosClearLib|IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
 
+[LibraryClasses.AARCH64]
+  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
+
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   #######################################
   # BaseCore Packages

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -41,7 +41,9 @@
   OemHookStatusCodeLib|MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
   SmmServicesTableLib|MdePkg/Library/SmmServicesTableLib/SmmServicesTableLib.inf
+  MmServicesTableLib|MdePkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLib.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
   UefiLib|MdePkg/Library/UefiLib/UefiLib.inf

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -88,15 +88,22 @@
   ReportStatusCodeLib|MdeModulePkg/Library/SmmReportStatusCodeLib/SmmReportStatusCodeLib.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
 
+[LibraryClasses.common.MM_STANDALONE]
+  MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
+  ReportStatusCodeLib|MdeModulePkg/Library/SmmReportStatusCodeLib/StandaloneMmReportStatusCodeLib.inf
+  HobLib|StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
+
 [Components]
   IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLib.inf
   IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.inf
   IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.inf
   IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.inf
   IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf
+  IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
   IpmiFeaturePkg/Library/BmcSmbusLibNull/BmcSmbusLibNull.inf
   IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
   IpmiFeaturePkg/GenericIpmi/Dxe/DxeGenericIpmi.inf
+  IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
   IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
   IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
   IpmiFeaturePkg/SpmiTable/SpmiTable.inf

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -60,7 +60,6 @@
 
 [LibraryClasses.AARCH64]
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
 
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   #######################################
@@ -107,18 +106,27 @@
   IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf
   IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
   IpmiFeaturePkg/Library/BmcSmbusLibNull/BmcSmbusLibNull.inf
-  IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLib.inf
-  IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.inf
-  IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.inf
-  IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.inf
-  IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf
-  IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
-  IpmiFeaturePkg/Library/BmcSmbusLibNull/BmcSmbusLibNull.inf
+  IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
+  IpmiFeaturePkg/GenericIpmi/Dxe/DxeGenericIpmi.inf
+  IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
+  IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
+  IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
+  IpmiFeaturePkg/SpmiTable/SpmiTable.inf
+  IpmiFeaturePkg/IpmiSmbios/IpmiSmbios.inf
+  IpmiFeaturePkg/IpmiFru/IpmiFru.inf
+  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+  IpmiFeaturePkg/SolStatus/SolStatus.inf
   IpmiFeaturePkg/Library/IpmiSelLib/IpmiSelLib.inf
+  IpmiFeaturePkg/IpmiWatchdog/Pei/IpmiWatchdogPei.inf
+  IpmiFeaturePkg/IpmiWatchdog/Dxe/IpmiWatchdogDxe.inf
   IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
   IpmiFeaturePkg/Library/IpmiWatchdogLib/IpmiWatchdogLib.inf
   IpmiFeaturePkg/Library/IpmiBootOptionLib/IpmiBootOptionLib.inf
+  IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
   IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
+  IpmiFeaturePkg/PlatformPowerRestorePolicyDefault/PlatformPowerRestorePolicyDefault.inf
+  IpmiFeaturePkg/IpmiSel/IpmiSel.inf
+
   # Transport Libraries
   IpmiFeaturePkg/Library/IpmiTransportLibNull/IpmiTransportLibNull.inf
   IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsIpmiTransportLib.inf
@@ -130,24 +138,6 @@
   # Mock Libraries
   IpmiFeaturePkg/Library/MockIpmi/IpmiTransportLibMock.inf
   IpmiFeaturePkg/Library/MockIpmi/IpmiBaseLibMock.inf
-
-[Components.IA32, Components.X64]
-  IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
-  IpmiFeaturePkg/GenericIpmi/Dxe/DxeGenericIpmi.inf
-  IpmiFeaturePkg/GenericIpmi/Smm/SmmGenericIpmi.inf
-  IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
-  IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
-  IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
-  IpmiFeaturePkg/SpmiTable/SpmiTable.inf
-  IpmiFeaturePkg/IpmiSmbios/IpmiSmbios.inf
-  IpmiFeaturePkg/IpmiFru/IpmiFru.inf
-  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
-  IpmiFeaturePkg/SolStatus/SolStatus.inf
-  IpmiFeaturePkg/IpmiWatchdog/Pei/IpmiWatchdogPei.inf
-  IpmiFeaturePkg/IpmiWatchdog/Dxe/IpmiWatchdogDxe.inf
-  IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
-  IpmiFeaturePkg/PlatformPowerRestorePolicyDefault/PlatformPowerRestorePolicyDefault.inf
-  IpmiFeaturePkg/IpmiSel/IpmiSel.inf
 
   # Functional Tests
   IpmiFeaturePkg/Test/FunctionalTest/IpmiShellTest/IpmiShellTest.inf {
@@ -171,3 +161,10 @@
 
   # Sample modules
   IpmiFeaturePkg/Samples/IpmiStatusReporter/Dxe/IpmiStatusReporterDxe.inf
+
+[Components.IA32, Components.X64]
+  IpmiFeaturePkg/GenericIpmi/Smm/SmmGenericIpmi.inf
+
+[LibraryClasses.ARM, LibraryClasses.AARCH64]
+  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
+  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -60,6 +60,7 @@
 
 [LibraryClasses.AARCH64]
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
+  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
 
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   #######################################
@@ -106,27 +107,18 @@
   IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf
   IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
   IpmiFeaturePkg/Library/BmcSmbusLibNull/BmcSmbusLibNull.inf
-  IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
-  IpmiFeaturePkg/GenericIpmi/Dxe/DxeGenericIpmi.inf
-  IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
-  IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
-  IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
-  IpmiFeaturePkg/SpmiTable/SpmiTable.inf
-  IpmiFeaturePkg/IpmiSmbios/IpmiSmbios.inf
-  IpmiFeaturePkg/IpmiFru/IpmiFru.inf
-  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
-  IpmiFeaturePkg/SolStatus/SolStatus.inf
+  IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLib.inf
+  IpmiFeaturePkg/Library/IpmiBaseLibNull/IpmiBaseLibNull.inf
+  IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.inf
+  IpmiFeaturePkg/Library/IpmiBaseLibPei/IpmiBaseLibPei.inf
+  IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.inf
+  IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
+  IpmiFeaturePkg/Library/BmcSmbusLibNull/BmcSmbusLibNull.inf
   IpmiFeaturePkg/Library/IpmiSelLib/IpmiSelLib.inf
-  IpmiFeaturePkg/IpmiWatchdog/Pei/IpmiWatchdogPei.inf
-  IpmiFeaturePkg/IpmiWatchdog/Dxe/IpmiWatchdogDxe.inf
   IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
   IpmiFeaturePkg/Library/IpmiWatchdogLib/IpmiWatchdogLib.inf
   IpmiFeaturePkg/Library/IpmiBootOptionLib/IpmiBootOptionLib.inf
-  IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
   IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
-  IpmiFeaturePkg/PlatformPowerRestorePolicyDefault/PlatformPowerRestorePolicyDefault.inf
-  IpmiFeaturePkg/IpmiSel/IpmiSel.inf
-
   # Transport Libraries
   IpmiFeaturePkg/Library/IpmiTransportLibNull/IpmiTransportLibNull.inf
   IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsIpmiTransportLib.inf
@@ -138,6 +130,24 @@
   # Mock Libraries
   IpmiFeaturePkg/Library/MockIpmi/IpmiTransportLibMock.inf
   IpmiFeaturePkg/Library/MockIpmi/IpmiBaseLibMock.inf
+
+[Components.IA32, Components.X64]
+  IpmiFeaturePkg/GenericIpmi/Pei/PeiGenericIpmi.inf
+  IpmiFeaturePkg/GenericIpmi/Dxe/DxeGenericIpmi.inf
+  IpmiFeaturePkg/GenericIpmi/Smm/SmmGenericIpmi.inf
+  IpmiFeaturePkg/GenericIpmi/StandaloneMm/StandaloneMmGenericIpmi.inf
+  IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
+  IpmiFeaturePkg/BmcAcpiPowerState/BmcAcpiPowerStateSmm.inf
+  IpmiFeaturePkg/SpmiTable/SpmiTable.inf
+  IpmiFeaturePkg/IpmiSmbios/IpmiSmbios.inf
+  IpmiFeaturePkg/IpmiFru/IpmiFru.inf
+  IpmiFeaturePkg/IpmiPowerRestorePolicy/IpmiPowerRestorePolicy.inf
+  IpmiFeaturePkg/SolStatus/SolStatus.inf
+  IpmiFeaturePkg/IpmiWatchdog/Pei/IpmiWatchdogPei.inf
+  IpmiFeaturePkg/IpmiWatchdog/Dxe/IpmiWatchdogDxe.inf
+  IpmiFeaturePkg/IpmiCmosClear/IpmiCmosClear.inf
+  IpmiFeaturePkg/PlatformPowerRestorePolicyDefault/PlatformPowerRestorePolicyDefault.inf
+  IpmiFeaturePkg/IpmiSel/IpmiSel.inf
 
   # Functional Tests
   IpmiFeaturePkg/Test/FunctionalTest/IpmiShellTest/IpmiShellTest.inf {
@@ -161,10 +171,3 @@
 
   # Sample modules
   IpmiFeaturePkg/Samples/IpmiStatusReporter/Dxe/IpmiStatusReporterDxe.inf
-
-[Components.IA32, Components.X64]
-  IpmiFeaturePkg/GenericIpmi/Smm/SmmGenericIpmi.inf
-
-[LibraryClasses.ARM, LibraryClasses.AARCH64]
-  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dsc
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dsc
@@ -58,9 +58,6 @@
   IpmiPlatformLib|IpmiFeaturePkg/Library/IpmiPlatformLibNull/IpmiPlatformLibNull.inf
   PlatformCmosClearLib|IpmiFeaturePkg/Library/PlatformCmosClearLibNull/PlatformCmosClearLibNull.inf
 
-[LibraryClasses.AARCH64]
-  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
-
 [LibraryClasses.common.PEI_CORE,LibraryClasses.common.PEIM]
   #######################################
   # BaseCore Packages

--- a/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.c
@@ -1,0 +1,98 @@
+/** @file
+  A Library to support all BMC access via IPMI command during MM Phase.
+
+  @copyright
+  Copyright 1999 - 2021 Intel Corporation. <BR>
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiDxe.h>
+#include <Protocol/IpmiTransportProtocol.h>
+#include <Library/IpmiBaseLib.h>
+#include <Library/MmServicesTableLib.h>
+#include <Library/DebugLib.h>
+
+STATIC IPMI_TRANSPORT  *mIpmiTransport = NULL;
+
+/**
+  Sends a IPMI command to the BMC and returns the response.
+
+  @param[in]      NetFunction       Net function of the command.
+  @param[in]      Command           IPMI command number.
+  @param[in]      CommandData       Command data buffer.
+  @param[in]      CommandDataSize   Size of command data.
+  @param[out]     ResponseData      Response Data buffer.
+  @param[in,out]  ResponseDataSize  Response data buffer size on input, size of
+                                    read data or required size on return.
+
+  @retval   EFI_SUCCESS             Successfully send IPMI command.
+  @retval   EFI_NOT_AVAILABLE_YET   Ipmi interface is not installed yet.
+**/
+EFI_STATUS
+EFIAPI
+IpmiSubmitCommand (
+  IN UINT8       NetFunction,
+  IN UINT8       Command,
+  IN UINT8       *CommandData,
+  IN UINT32      CommandDataSize,
+  OUT UINT8      *ResponseData,
+  IN OUT UINT32  *ResponseDataSize
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mIpmiTransport == NULL) {
+    Status = gMmst->MmLocateProtocol (&gSmmIpmiTransportProtocolGuid, NULL, (VOID **)&mIpmiTransport);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
+      return Status;
+    }
+  }
+
+  Status = mIpmiTransport->IpmiSubmitCommand (
+                             mIpmiTransport,
+                             NetFunction,
+                             0,
+                             Command,
+                             CommandData,
+                             CommandDataSize,
+                             ResponseData,
+                             ResponseDataSize
+                             );
+  return Status;
+}
+
+/**
+  Gets the current status of the BMC from the IPMI module.
+
+  @param[out]   BmcStatus     The current status of the BMC.
+  @param[out]   ComAddress    The address of the BMC.
+
+  @retval   EFI_SUCCESS             Successfully retrieved BMC status
+  @retval   EFI_NOT_FOUND           Ipmi interface is not installed yet.
+**/
+EFI_STATUS
+EFIAPI
+GetBmcStatus (
+  OUT BMC_STATUS      *BmcStatus,
+  OUT SM_COM_ADDRESS  *ComAddress
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mIpmiTransport == NULL) {
+    Status = gMmst->MmLocateProtocol (&gSmmIpmiTransportProtocolGuid, NULL, (VOID **)&mIpmiTransport);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
+      return Status;
+    }
+  }
+
+  Status = mIpmiTransport->GetBmcStatus (
+                             mIpmiTransport,
+                             BmcStatus,
+                             ComAddress
+                             );
+  return Status;
+}

--- a/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.c
@@ -45,7 +45,7 @@ IpmiSubmitCommand (
   if (mIpmiTransport == NULL) {
     Status = gMmst->MmLocateProtocol (&gSmmIpmiTransportProtocolGuid, NULL, (VOID **)&mIpmiTransport);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __func__, Status));
       return Status;
     }
   }
@@ -84,7 +84,7 @@ GetBmcStatus (
   if (mIpmiTransport == NULL) {
     Status = gMmst->MmLocateProtocol (&gSmmIpmiTransportProtocolGuid, NULL, (VOID **)&mIpmiTransport);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __func__, Status));
       return Status;
     }
   }

--- a/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.inf
@@ -1,0 +1,33 @@
+## @file
+#
+# @copyright
+# Copyright 2010 - 2021 Intel Corporation. <BR>
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 1.26
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  BASE_NAME                      = IpmiBaseLibMm
+  FILE_GUID                      = 06C28B6D-F15F-42C3-8316-01BD3E93D2DE
+  MODULE_TYPE                    = MM_STANDALONE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IpmiBaseLib|MM_STANDALONE MM_CORE_STANDALONE
+
+[sources]
+  IpmiBaseLibMm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  DebugLib
+  MmServicesTableLib
+
+[Protocols]
+  gSmmIpmiTransportProtocolGuid
+
+[Depex]
+  TRUE


### PR DESCRIPTION
## Description

Implement the StandaloneMmGenericIpmi driver

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified the build and boot on a simulator

## Integration Instructions

Include the driver in DSC and FDF file
