### PR TITLE
Add IpmiSetSensorThreshold and IpmiGetSensorThreshold in the MockIpmiCommandLib

### DIFF
--- a/IpmiFeaturePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiCommandLib.h
+++ b/IpmiFeaturePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiCommandLib.h
@@ -340,6 +340,24 @@ struct MockIpmiCommandLib {
      IN OUT UINT32              *GetSdrResponseSize
     )
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiSetSensorThreshold,
+    (
+     IN IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA  *SetSensorThresholdRequestData,
+     OUT UINT8                                         *CompletionCode
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetSensorThreshold,
+    (
+     IN UINT8                                            SensorNumber,
+     OUT IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA  *GetSensorThresholdResponse
+    )
+    );
 };
 
 #endif

--- a/IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.cpp
+++ b/IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.cpp
@@ -44,3 +44,5 @@ MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSelTime, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetSelTime, 2, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSdrRepositoryInfo, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSdr, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiSetSensorThreshold, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiCommandLib, IpmiGetSensorThreshold, 2, EFIAPI);


### PR DESCRIPTION
Add IpmiSetSensorThreshold and IpmiGetSensorThreshold in the MockIpmiCommandLib

## Description

Add IpmiSetSensorThreshold and IpmiGetSensorThreshold in the MockIpmiCommandLib

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests component can call these mock functions success

## Integration Instructions

N/A
