### PR TITLE
Supports KCS command register declare

### DIFF
--- a/IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
+++ b/IpmiFeaturePkg/BmcAcpi/BmcAcpi.inf
@@ -37,6 +37,7 @@
 
 [Pcd]
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoCmdRegister
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId
   gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId
 

--- a/IpmiFeaturePkg/BmcAcpi/BmcSsdt/IpmiOprRegions.asi
+++ b/IpmiFeaturePkg/BmcAcpi/BmcSsdt/IpmiOprRegions.asi
@@ -43,7 +43,9 @@ Device(IPMC)
     Name(_CRS, ResourceTemplate()
     {
         // Uses 8-bit ports 0xCA2-0xCA5
-        IO(Decode16, 0xCA2, 0xCA2, 0, 2)
+        IO(Decode16, FixedPcdGet8 (PcdIpmiIoBaseAddress), FixedPcdGet8 (PcdIpmiIoBaseAddress), 0, 1)
+        IO(Decode16, FixedPcdGet8 (PcdIpmiIoCmdRegister), FixedPcdGet8 (PcdIpmiIoCmdRegister), 0, 1)
+        
     })
 
     Name(_HID, "IPI0001")           // IPMI device

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dec
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dec
@@ -60,7 +60,13 @@
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCommandMaxReties|3|UINT8|0xF0000004
   gIpmiFeaturePkgTokenSpaceGuid.PcdBmcTimeoutSeconds|30|UINT8|0xF0000005
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiSelOemManufacturerId|{0, 0, 0}|VOID*|0xF0000007
+  #
+  # KCS Status Register I/O Address (Normally CA2)
+  #
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress|0xCA2|UINT16|0xF0000009
+  #
+  # KCS Command Register I/O Address (Normally CA3)
+  #
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoCmdRegister|0xCA3|UINT16|0xF000000A
   #
   # IPMI Interface Type

--- a/IpmiFeaturePkg/IpmiFeaturePkg.dec
+++ b/IpmiFeaturePkg/IpmiFeaturePkg.dec
@@ -60,7 +60,8 @@
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiCommandMaxReties|3|UINT8|0xF0000004
   gIpmiFeaturePkgTokenSpaceGuid.PcdBmcTimeoutSeconds|30|UINT8|0xF0000005
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiSelOemManufacturerId|{0, 0, 0}|VOID*|0xF0000007
-  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress|0xCA2|UINT16|0xF000000A
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress|0xCA2|UINT16|0xF0000009
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoCmdRegister|0xCA3|UINT16|0xF000000A
   #
   # IPMI Interface Type
   #

--- a/IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsBmc.c
+++ b/IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsBmc.c
@@ -72,17 +72,19 @@ Returns:
   UINT8       KcsData;
   KCS_STATUS  KcsStatus;
   UINT16      KcsPort;
+  UINT16      KcsCmdReg;
   UINT8       RetryCount;
   UINT64      TimeOut;
 
   KcsPort    = PcdGet16 (PcdIpmiIoBaseAddress);
+  KcsCmdReg  = PcdGet16 (PcdIpmiIoCmdRegister);
   TimeOut    = 0;
   RetryCount = 0;
   while (RetryCount < KCS_ABORT_RETRY_COUNT) {
     TimeOut = 0;
     do {
       MicroSecondDelay (IPMI_DELAY_UNIT);
-      KcsStatus.RawData = IoRead8 (KcsPort + 1);
+      KcsStatus.RawData = IoRead8 (KcsCmdReg);
       if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
         RetryCount = KCS_ABORT_RETRY_COUNT;
         break;
@@ -96,12 +98,12 @@ Returns:
     }
 
     KcsData = KCS_ABORT;
-    IoWrite8 ((KcsPort + 1), KcsData);
+    IoWrite8 ((KcsCmdReg), KcsData);
 
     TimeOut = 0;
     do {
       MicroSecondDelay (IPMI_DELAY_UNIT);
-      KcsStatus.RawData = IoRead8 (KcsPort + 1);
+      KcsStatus.RawData = IoRead8 (KcsCmdReg);
       if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
         Status = EFI_DEVICE_ERROR;
         goto LabelError;
@@ -118,7 +120,7 @@ Returns:
     TimeOut = 0;
     do {
       MicroSecondDelay (IPMI_DELAY_UNIT);
-      KcsStatus.RawData = IoRead8 (KcsPort + 1);
+      KcsStatus.RawData = IoRead8 (KcsCmdReg);
       if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
         Status = EFI_DEVICE_ERROR;
         goto LabelError;
@@ -131,7 +133,7 @@ Returns:
       TimeOut = 0;
       do {
         MicroSecondDelay (IPMI_DELAY_UNIT);
-        KcsStatus.RawData = IoRead8 (KcsPort + 1);
+        KcsStatus.RawData = IoRead8 (KcsCmdReg);
         if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
           Status = EFI_DEVICE_ERROR;
           goto LabelError;
@@ -149,7 +151,7 @@ Returns:
       TimeOut = 0;
       do {
         MicroSecondDelay (IPMI_DELAY_UNIT);
-        KcsStatus.RawData = IoRead8 (KcsPort + 1);
+        KcsStatus.RawData = IoRead8 (KcsCmdReg);
         if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
           Status = EFI_DEVICE_ERROR;
           goto LabelError;
@@ -162,7 +164,7 @@ Returns:
         TimeOut = 0;
         do {
           MicroSecondDelay (IPMI_DELAY_UNIT);
-          KcsStatus.RawData = IoRead8 (KcsPort + 1);
+          KcsStatus.RawData = IoRead8 (KcsCmdReg);
           if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
             Status = EFI_DEVICE_ERROR;
             goto LabelError;
@@ -222,6 +224,7 @@ Returns:
   EFI_STATUS  Status;
   KCS_STATUS  KcsStatus;
   UINT16      KcsPort;
+  UINT16      KcsCmdReg;
   UINT64      TimeOut;
 
   if (Idle == NULL) {
@@ -230,11 +233,12 @@ Returns:
 
   *Idle = FALSE;
 
-  TimeOut = 0;
-  KcsPort = PcdGet16 (PcdIpmiIoBaseAddress);
+  TimeOut   = 0;
+  KcsPort   = PcdGet16 (PcdIpmiIoBaseAddress);
+  KcsCmdReg = PcdGet16 (PcdIpmiIoCmdRegister);
   do {
     MicroSecondDelay (IPMI_DELAY_UNIT);
-    KcsStatus.RawData = IoRead8 (KcsPort + 1);
+    KcsStatus.RawData = IoRead8 (KcsCmdReg);
     if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
       Status = EFI_DEVICE_ERROR;
       goto LabelError;
@@ -261,7 +265,7 @@ Returns:
     TimeOut = 0;
     do {
       MicroSecondDelay (IPMI_DELAY_UNIT);
-      KcsStatus.RawData = IoRead8 (KcsPort + 1);
+      KcsStatus.RawData = IoRead8 (KcsCmdReg);
       if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
         Status = EFI_DEVICE_ERROR;
         goto LabelError;
@@ -310,18 +314,19 @@ Returns:
   KCS_STATUS  KcsStatus;
   UINT8       KcsData;
   UINT16      KcsIoBase;
+  UINT16      KcsCmdReg;
   EFI_STATUS  Status;
   UINT8       i;
   BOOLEAN     Idle;
   UINT64      TimeOut;
 
   KcsIoBase = PcdGet16 (PcdIpmiIoBaseAddress);
-
-  TimeOut = 0;
+  KcsCmdReg = PcdGet16 (PcdIpmiIoCmdRegister);
+  TimeOut   = 0;
 
   do {
     MicroSecondDelay (IPMI_DELAY_UNIT);
-    KcsStatus.RawData = IoRead8 (KcsIoBase + 1);
+    KcsStatus.RawData = IoRead8 (KcsCmdReg);
     if ((KcsStatus.RawData == 0xFF) || (TimeOut >= IpmiTimeoutPeriod)) {
       if ((Status = KcsErrorExit (IpmiTimeoutPeriod)) != EFI_SUCCESS) {
         return Status;
@@ -332,7 +337,7 @@ Returns:
   } while (KcsStatus.Status.Ibf);
 
   KcsData = KCS_WRITE_START;
-  IoWrite8 ((KcsIoBase + 1), KcsData);
+  IoWrite8 ((KcsCmdReg), KcsData);
   if ((Status = KcsCheckStatus (IpmiTimeoutPeriod, KcsWriteState, &Idle)) != EFI_SUCCESS) {
     return Status;
   }
@@ -344,7 +349,7 @@ Returns:
       }
 
       KcsData = KCS_WRITE_END;
-      IoWrite8 ((KcsIoBase + 1), KcsData);
+      IoWrite8 ((KcsCmdReg), KcsData);
     }
 
     Status = KcsCheckStatus (IpmiTimeoutPeriod, KcsWriteState, &Idle);

--- a/IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsIpmiTransportLib.inf
+++ b/IpmiFeaturePkg/Library/IpmiTransportLibKcs/KcsIpmiTransportLib.inf
@@ -30,3 +30,4 @@
 
 [Pcd]
   gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress
+  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoCmdRegister


### PR DESCRIPTION
## Description

KCS data and command registers may be decoded as "discontinuous," so a new PCD is added to manage the command register.

For example:

IO 62h/66h as KCS data and command registers.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This modification does not affect the original operation.
If the system declares CA2h/CA3h, make sure the IPMI KCS works as expected.

## Integration Instructions

If your system KCS data and command registers may be decoded as "discontinuous," please refer this:

Example: 

IO 62h/66h as KCS data and command registers.

```ini
  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoBaseAddress|0x62|UINT16|0xF0000009
  gIpmiFeaturePkgTokenSpaceGuid.PcdIpmiIoCmdRegister|0x66|UINT16|0xF000000A
```

The IPMI device:
Original
![IPMC_ORI](https://github.com/user-attachments/assets/b60b7701-744c-4a52-a419-e1124cb957ea)
Modification
![IPMC_MOD](https://github.com/user-attachments/assets/5f099f2a-335a-4cdf-b11b-83bda4cb79f5)