### PR TITLE
Initialize the GuidResponse variable in IpmiGetSystemUuid

### DIFF
--- a/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnApp.c
+++ b/IpmiFeaturePkg/Library/IpmiCommandLib/IpmiCommandLibNetFnApp.c
@@ -276,6 +276,7 @@ IpmiGetSystemUuid (
   //   the response from Get System Guid is the same format. Reusing the structure here.
   IPMI_GET_SYSTEM_GUID_RESPONSE  GuidResponse;
 
+  ZeroMem (&GuidResponse, sizeof (GuidResponse));
   Status = EFI_INVALID_PARAMETER;
   if (SystemGuid != NULL) {
     DataSize = sizeof (IPMI_GET_DEVICE_GUID_RESPONSE);


### PR DESCRIPTION
## Description

Initialize the GuidResponse variable in IpmiGetSystemUuid to prevent Random Value when using IpmiBaseLibNull

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified with BIOS build with IpmiBaseLibNull

## Integration Instructions

N/A
