### PR TITLE
Add MockIpmiBootOptionLib for GoogleTest

### DIFF
--- a/IpmiFeaturePkg/Test/IpmiFeaturePkgHostTest.dsc
+++ b/IpmiFeaturePkg/Test/IpmiFeaturePkgHostTest.dsc
@@ -67,3 +67,4 @@
   IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiSelLib/MockIpmiSelLib.inf
   IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiCommandLib/MockIpmiCommandLib.inf
   IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiBaseLib/MockIpmiBaseLib.inf
+  IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiBootOptionLib/MockIpmiBootOptionLib.inf

--- a/IpmiFeaturePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiBootOptionLib.h
+++ b/IpmiFeaturePkg/Test/Mock/Include/GoogleTest/Library/MockIpmiBootOptionLib.h
@@ -1,0 +1,38 @@
+/** @file MockIpmiBootOptionLib.h
+  Google Test mocks for IpmiBootOptionLib
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_IPMI_BOOT_OPTION_LIB_H_
+#define MOCK_IPMI_BOOT_OPTION_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/IpmiBootOptionLib.h>
+}
+
+struct MockIpmiBootOptionLib {
+  MOCK_INTERFACE_DECLARATION (MockIpmiBootOptionLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetBootDevice,
+    (
+     OUT IPMI_BOOT_OPTION_SELECTOR  *Selector
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    IpmiGetCmosClearOption,
+    (
+     OUT BOOLEAN  *ClearCmos
+    )
+    );
+};
+
+#endif

--- a/IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiBootOptionLib/MockIpmiBootOptionLib.cpp
+++ b/IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiBootOptionLib/MockIpmiBootOptionLib.cpp
@@ -1,0 +1,12 @@
+/** @file MockIpmiBootOptionLib.cpp
+  Google Test mocks for IpmiBootOptionLib
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockIpmiBootOptionLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockIpmiBootOptionLib);
+MOCK_FUNCTION_DEFINITION (MockIpmiBootOptionLib, IpmiGetBootDevice, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockIpmiBootOptionLib, IpmiGetCmosClearOption, 1, EFIAPI);

--- a/IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiBootOptionLib/MockIpmiBootOptionLib.inf
+++ b/IpmiFeaturePkg/Test/Mock/Library/GoogleTest/MockIpmiBootOptionLib/MockIpmiBootOptionLib.inf
@@ -1,0 +1,33 @@
+## @file MockIpmiBootOptionLib.inf
+# Google Test mocks for IpmiBootOptionLib
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockIpmiBootOptionLib
+  FILE_GUID                      = 5D6E7F8A-9B0C-1D2E-3F4A-5B6C7D8E9F0A
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IpmiBootOptionLib
+  PI_SPECIFICATION_VERSION       = 0x0001000A
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockIpmiBootOptionLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  IpmiFeaturePkg/IpmiFeaturePkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

Add mock library for IpmiBootOptionLib to support GoogleTest-based unit testing.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Pipeline Test Pass
Unit tests component can call these mock functions success

## Integration Instructions

N/A