### PR TITLE
IpmiFeaturePkg: Added NULL check for located IPMI protocol

### DIFF
--- a/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibDxe/IpmiBaseLibDxe.c
@@ -46,6 +46,11 @@ IpmiSubmitCommand (
       DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
       return Status;
     }
+
+    if (mIpmiTransport == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: ERROR - mIpmiTransport is NULL.\n", __FUNCTION__));
+      return EFI_ABORTED;
+    }
   }
 
   Status = mIpmiTransport->IpmiSubmitCommand (
@@ -84,6 +89,11 @@ GetBmcStatus (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
       return Status;
+    }
+
+    if (mIpmiTransport == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: ERROR - mIpmiTransport is NULL.\n", __FUNCTION__));
+      return EFI_ABORTED;
     }
   }
 

--- a/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibMm/IpmiBaseLibMm.c
@@ -48,6 +48,11 @@ IpmiSubmitCommand (
       DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __func__, Status));
       return Status;
     }
+
+    if (mIpmiTransport == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: ERROR - mIpmiTransport is NULL.\n", __func__));
+      return EFI_ABORTED;
+    }
   }
 
   Status = mIpmiTransport->IpmiSubmitCommand (
@@ -86,6 +91,11 @@ GetBmcStatus (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __func__, Status));
       return Status;
+    }
+
+    if (mIpmiTransport == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: ERROR - mIpmiTransport is NULL.\n", __func__));
+      return EFI_ABORTED;
     }
   }
 

--- a/IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.c
+++ b/IpmiFeaturePkg/Library/IpmiBaseLibSmm/IpmiBaseLibSmm.c
@@ -48,6 +48,11 @@ IpmiSubmitCommand (
       DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
       return Status;
     }
+
+    if (mIpmiTransport == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: ERROR - mIpmiTransport is NULL.\n", __FUNCTION__));
+      return EFI_ABORTED;
+    }
   }
 
   Status = mIpmiTransport->IpmiSubmitCommand (
@@ -86,6 +91,11 @@ GetBmcStatus (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to locate IPMI protocol. %r\n", __FUNCTION__, Status));
       return Status;
+    }
+
+    if (mIpmiTransport == NULL) {
+      DEBUG ((DEBUG_ERROR, "%a: ERROR - mIpmiTransport is NULL.\n", __FUNCTION__));
+      return EFI_ABORTED;
     }
   }
 


### PR DESCRIPTION
## Description

The located protocol pointer could be null even the status is success in rare cases.
Added a null check after locating protocol to prevent null pointer dereference.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested boot on real server platform, the IPMI feature confirmed working.

## Integration Instructions

N/A